### PR TITLE
fix(geo): replace deprecated GEORADIUS with GEOSEARCH (#70)

### DIFF
--- a/backend/app/services/geolocation.py
+++ b/backend/app/services/geolocation.py
@@ -120,12 +120,12 @@ class GeolocationService:
             # Convert km to meters for Redis
             radius_m = radius_km * 1000
 
-            # Use GEORADIUS to find nearby artisans
-            results = await cache.redis.georadius(
-                self.redis_key,
-                float(longitude),
-                float(latitude),
-                radius_m,
+            # Use GEOSEARCH to find nearby artisans
+            results = await cache.redis.geosearch(
+                name=self.redis_key,
+                longitude=float(longitude),
+                latitude=float(latitude),
+                radius=radius_m,
                 unit="m",
                 withdist=True,
                 withcoord=True,

--- a/backend/app/tests/test_search.py
+++ b/backend/app/tests/test_search.py
@@ -38,11 +38,11 @@ class MockRedisGeo:
             return 1
         return 0
 
-    async def georadius(
+    async def geosearch(
         self,
-        key,
-        lon,
-        lat,
+        name,
+        longitude,
+        latitude,
         radius,
         unit="m",
         withdist=False,
@@ -50,18 +50,18 @@ class MockRedisGeo:
         sort="ASC",
         count=None,
     ):
-        if key not in self.geo_data:
+        if name not in self.geo_data:
             return []
 
-        center_lon = float(lon)
-        center_lat = float(lat)
+        center_lon = float(longitude)
+        center_lat = float(latitude)
         radius_m = float(radius)
         if unit == "km":
             radius_m *= 1000
 
         results = []
 
-        for member, coords in self.geo_data[key].items():
+        for member, coords in self.geo_data[name].items():
             member_lon, member_lat = coords
 
             # Simplified Haversine for the mock
@@ -113,7 +113,7 @@ def mock_redis():
     # Create an AsyncMock that delegates relevant calls to our MockRedisGeo
     mock = AsyncMock()
     mock.geoadd.side_effect = mock_geo.geoadd
-    mock.georadius.side_effect = mock_geo.georadius
+    mock.geosearch.side_effect = mock_geo.geosearch
     mock.hset.side_effect = mock_geo.hset
     mock.delete.side_effect = mock_geo.delete
     mock.zrem.side_effect = mock_geo.zrem

--- a/backend/docs/artisan_geolocation.md
+++ b/backend/docs/artisan_geolocation.md
@@ -229,17 +229,21 @@ redis_client.hset(
 
 #### Finding Nearby Artisans
 ```python
-# Search within radius
-nearby_results = redis_client.georadius(
-    "artisans:locations",
-    longitude, latitude,
-    radius_km, unit="km",
+# Search within radius using GEOSEARCH (Redis 6.2+)
+nearby_results = redis_client.geosearch(
+    name="artisans:locations",
+    longitude=longitude,
+    latitude=latitude,
+    radius=radius_km,
+    unit="km",
     withdist=True,
     withcoord=True,
     sort="ASC",
     count=limit
 )
 ```
+
+**Note:** The `GEOSEARCH` command replaced the deprecated `GEORADIUS` command in Redis 6.2. `GEORADIUS` was removed in Redis 7.0+.
 
 #### Removing Artisan Location
 ```python
@@ -252,7 +256,7 @@ redis_client.delete(f"artisan:location:{artisan_id}")
 
 ### Performance Optimization
 
-1. **Geospatial Indexing:** Redis GEORADIUS provides O(N+log(M)) complexity
+1. **Geospatial Indexing:** Redis GEOSEARCH provides O(N+log(M)) complexity
 2. **Caching:** Location data cached in Redis for fast retrieval
 3. **Batch Operations:** Sync operations handle multiple artisans efficiently
 4. **TTL Management:** Location cache with appropriate expiration


### PR DESCRIPTION
`GEORADIUS` was removed in Redis 7.0+. Calls to it raise a `ResponseError` silently swallowed by a broad `except Exception`, causing "Find Nearby Artisans" to return empty results with no visible error on any modern Redis deployment.

---

### Changes

**`geolocation.py`**
- Replaced `georadius` with `geosearch` in `find_nearby_artisans`
- Updated param names: `key` → `name`, `lon`/`lat` → `longitude`/`latitude`
- Return shape and external behavior unchanged

**`test_search.py`**
- Replaced `georadius` mock method in `MockRedisGeo` with `geosearch`
- Updated fixture wiring and method signature to match new API

**`artisan_geolocation.md`**
- Updated code examples to use `geosearch`
- Added note: `GEORADIUS` deprecated in Redis 6.2, removed in Redis 7.0+

---

### Verification
- No `georadius` references remain in Python code
- All files compile successfully
- Run tests via `make test` in Docker to confirm

Closes #70