### PR TITLE
fix: 🟠 LOW — Contracts CI Missing cargo clippy Linting Step

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     name: Test Contracts
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -25,6 +25,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+          components: clippy
 
       - name: Cache cargo registry
         uses: actions/cache@v3
@@ -49,6 +50,10 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-build-target-
+
+      - name: Run clippy
+        working-directory: contracts
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run tests
         working-directory: contracts


### PR DESCRIPTION
## Summary
Fixes #88

## Changes
- Added cargo clippy step before cargo test in contracts.yml
- Included clippy component in rust-toolchain action
- Using --all-targets --all-features -- -D warnings for comprehensive linting
- Clippy now gates testing to catch compile errors and code quality issues

## Why this matters
The contracts CI pipeline was missing cargo clippy, Rust's official linter. This means:
- Compile errors (like duplicate methods) could be masked by stale cache
- Code quality issues accumulate without automated feedback
- Non-idiomatic Rust patterns aren't caught before merge

## Testing
- [ ] cargo clippy --all-targets --all-features -- -D warnings passes
- [ ] cargo test passes
- [ ] cargo build --release passes

---
*Generated by [pr-contributor](https://github.com/sypherin/openclaw-config) — autonomous contribution bot*