### PR TITLE
[#83] MEDIUM — CI Test Job Missing Redis Service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,15 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
     
     steps:
     - uses: actions/checkout@v4
@@ -81,6 +90,9 @@ jobs:
     - name: Run tests
       env:
         DATABASE_URL: postgresql://stellarts:stellarts_test@localhost:5432/stellarts_test_db
+        REDIS_URL: redis://localhost:6379/0
+        REDIS_HOST: localhost
+        REDIS_PORT: 6379
         SECRET_KEY: test-secret-key
         DEBUG: True
         STELLAR_ESCROW_PUBLIC: "GDUMMY"


### PR DESCRIPTION
## Summary
- Add a Redis service container to the CI 	est job so backend tests have all required runtime dependencies.
- Export Redis environment variables for the test step to align with backend configuration.

Closes #83