### PR TITLE
ISSUE-11: Add multimodal ingestion and validation endpoint

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,6 +1,16 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import admin, artisan, auth, booking, health, payments, user
+from app.api.v1.endpoints import (
+    admin,
+    artisan,
+    auth,
+    booking,
+    health,
+    ingestion,
+    payments,
+    stats,
+    user,
+)
 
 api_router = APIRouter()
 
@@ -11,5 +21,6 @@ api_router.include_router(user.router, tags=["users"])
 api_router.include_router(booking.router, tags=["bookings"])
 api_router.include_router(artisan.router, tags=["artisans"])
 api_router.include_router(admin.router, tags=["admin"])
+api_router.include_router(ingestion.router, tags=["ingestion"])
 api_router.include_router(payments.router, prefix="/payments", tags=["payments"])
 api_router.include_router(stats.router, tags=["stats"])

--- a/backend/app/api/v1/endpoints/ingestion.py
+++ b/backend/app/api/v1/endpoints/ingestion.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from fastapi import APIRouter, File, Form, UploadFile, WebSocket, WebSocketDisconnect, status
+
+from app.schemas.ingestion import VisionToScopeResponse
+from app.services.analysis_queue import analysis_queue
+from app.services.ingestion_realtime import ingestion_connection_manager
+from app.services.media_ingestion import build_job_payload, media_ingestion_service
+
+router = APIRouter(prefix="/ingestion")
+
+
+@router.post(
+    "/vision-to-scope",
+    response_model=VisionToScopeResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def ingest_vision_to_scope(
+    session_id: str | None = Form(default=None),
+    client_reference: str | None = Form(default=None),
+    photos: list[UploadFile] = File(default=[]),
+    videos: list[UploadFile] = File(default=[]),
+    voice_notes: list[UploadFile] = File(default=[]),
+):
+    job_id = str(uuid4())
+    result = await media_ingestion_service.process(
+        job_id=job_id,
+        photos=photos,
+        videos=videos,
+        voice_notes=voice_notes,
+    )
+
+    if result.accepted:
+        payload = build_job_payload(
+            job_id=job_id,
+            session_id=session_id,
+            client_reference=client_reference,
+            stored_media=result.stored_media,
+        )
+        await analysis_queue.enqueue(payload)
+
+        response = VisionToScopeResponse(
+            job_id=job_id,
+            session_id=session_id,
+            status="accepted",
+            forwarded_to_queue=True,
+            queue_name=analysis_queue.queue_name,
+            feedback=[],
+            stored_media=result.stored_media,
+            created_at=datetime.now(UTC),
+        )
+    else:
+        response = VisionToScopeResponse(
+            job_id=job_id,
+            session_id=session_id,
+            status="rejected",
+            forwarded_to_queue=False,
+            queue_name=analysis_queue.queue_name,
+            feedback=result.feedback,
+            stored_media=[],
+            created_at=datetime.now(UTC),
+        )
+
+    await ingestion_connection_manager.publish(
+        session_id,
+        {
+            "event": "vision_to_scope.validation",
+            "payload": response.model_dump(mode="json"),
+        },
+    )
+
+    return response
+
+
+@router.websocket("/ws/{session_id}")
+async def ingestion_updates(session_id: str, websocket: WebSocket):
+    await ingestion_connection_manager.connect(session_id, websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        ingestion_connection_manager.disconnect(session_id, websocket)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -55,7 +55,17 @@ class Settings(BaseSettings):
     STRIPE_SECRET_KEY: str | None = None
     STRIPE_PUBLISHABLE_KEY: str | None = None
 
-        # Soroban Configuration
+    # Multimodal ingestion
+    INGESTION_STORAGE_DIR: str = "storage/vision_to_scope"
+    INGESTION_MIN_IMAGE_WIDTH: int = 1280
+    INGESTION_MIN_IMAGE_HEIGHT: int = 720
+    INGESTION_MIN_IMAGE_BYTES: int = 5_000
+    INGESTION_MIN_VIDEO_BYTES: int = 500_000
+    INGESTION_MIN_AUDIO_BYTES: int = 10_000
+    INGESTION_MIN_BRIGHTNESS: float = 50.0
+    INGESTION_MIN_SHARPNESS: float = 12.0
+
+    # Soroban Configuration
     SOROBAN_RPC_URL: str = "https://soroban-testnet.stellar.org"
     ESCROW_CONTRACT_ID: str | None = None
     REPUTATION_CONTRACT_ID: str | None = None

--- a/backend/app/schemas/ingestion.py
+++ b/backend/app/schemas/ingestion.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class ValidationFeedback(BaseModel):
+    code: str
+    message: str
+    media_type: Literal["photo", "video", "voice"]
+    filename: str | None = None
+
+
+class StoredMedia(BaseModel):
+    media_type: Literal["photo", "video", "voice"]
+    filename: str
+    content_type: str
+    size_bytes: int
+    storage_path: str
+    metadata: dict[str, float | int | str | bool | None] = Field(default_factory=dict)
+
+
+class VisionToScopeResponse(BaseModel):
+    job_id: str
+    session_id: str | None = None
+    status: Literal["accepted", "rejected"]
+    forwarded_to_queue: bool
+    queue_name: str
+    feedback: list[ValidationFeedback] = Field(default_factory=list)
+    stored_media: list[StoredMedia] = Field(default_factory=list)
+    created_at: datetime

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from enum import StrEnum
+from enum import Enum, StrEnum
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
 

--- a/backend/app/services/analysis_queue.py
+++ b/backend/app/services/analysis_queue.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Any
+
+
+class AnalysisQueue:
+    def __init__(self) -> None:
+        self.queue_name = "analysis-node"
+        self._jobs: deque[dict[str, Any]] = deque()
+
+    async def enqueue(self, payload: dict[str, Any]) -> None:
+        self._jobs.append(payload)
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        return list(self._jobs)
+
+    def clear(self) -> None:
+        self._jobs.clear()
+
+
+analysis_queue = AnalysisQueue()

--- a/backend/app/services/ingestion_realtime.py
+++ b/backend/app/services/ingestion_realtime.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+from fastapi import WebSocket
+
+
+class IngestionConnectionManager:
+    def __init__(self) -> None:
+        self._connections: dict[str, set[WebSocket]] = defaultdict(set)
+
+    async def connect(self, session_id: str, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self._connections[session_id].add(websocket)
+
+    def disconnect(self, session_id: str, websocket: WebSocket) -> None:
+        session_connections = self._connections.get(session_id)
+        if not session_connections:
+            return
+
+        session_connections.discard(websocket)
+        if not session_connections:
+            self._connections.pop(session_id, None)
+
+    async def publish(self, session_id: str | None, message: dict) -> None:
+        if not session_id:
+            return
+
+        for websocket in list(self._connections.get(session_id, set())):
+            await websocket.send_json(message)
+
+
+ingestion_connection_manager = IngestionConnectionManager()

--- a/backend/app/services/media_ingestion.py
+++ b/backend/app/services/media_ingestion.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from io import BytesIO
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi import UploadFile
+from PIL import Image, ImageFilter, ImageStat
+
+from app.core.config import settings
+from app.schemas.ingestion import StoredMedia, ValidationFeedback
+
+ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp"}
+ALLOWED_VIDEO_TYPES = {"video/mp4", "video/quicktime", "video/webm"}
+ALLOWED_AUDIO_TYPES = {
+    "audio/mpeg",
+    "audio/mp3",
+    "audio/mp4",
+    "audio/wav",
+    "audio/x-wav",
+    "audio/webm",
+    "audio/ogg",
+    "audio/aac",
+}
+
+
+@dataclass
+class IngestionResult:
+    stored_media: list[StoredMedia]
+    feedback: list[ValidationFeedback]
+
+    @property
+    def accepted(self) -> bool:
+        return not self.feedback
+
+
+class MediaIngestionService:
+    def __init__(self) -> None:
+        self.storage_root = Path(settings.INGESTION_STORAGE_DIR)
+
+    async def process(
+        self,
+        *,
+        job_id: str,
+        photos: list[UploadFile],
+        videos: list[UploadFile],
+        voice_notes: list[UploadFile],
+    ) -> IngestionResult:
+        stored_media: list[StoredMedia] = []
+        feedback: list[ValidationFeedback] = []
+
+        if not any([photos, videos, voice_notes]):
+            feedback.append(
+                ValidationFeedback(
+                    code="empty_payload",
+                    message="Add at least one photo, video, or voice note before submitting.",
+                    media_type="photo",
+                )
+            )
+            return IngestionResult(stored_media=stored_media, feedback=feedback)
+
+        for photo in photos:
+            result = await self._handle_photo(job_id, photo)
+            if isinstance(result, ValidationFeedback):
+                feedback.append(result)
+            else:
+                stored_media.append(result)
+
+        for video in videos:
+            result = await self._handle_binary_media(
+                job_id=job_id,
+                upload=video,
+                media_type="video",
+                allowed_types=ALLOWED_VIDEO_TYPES,
+                min_size=settings.INGESTION_MIN_VIDEO_BYTES,
+                too_small_message=(
+                    "The video is too short or heavily compressed. Please upload a clearer, higher-resolution clip."
+                ),
+            )
+            if isinstance(result, ValidationFeedback):
+                feedback.append(result)
+            else:
+                stored_media.append(result)
+
+        for voice_note in voice_notes:
+            result = await self._handle_binary_media(
+                job_id=job_id,
+                upload=voice_note,
+                media_type="voice",
+                allowed_types=ALLOWED_AUDIO_TYPES,
+                min_size=settings.INGESTION_MIN_AUDIO_BYTES,
+                too_small_message=(
+                    "The voice note is too short or silent. Please re-record with a clearer description of the work scope."
+                ),
+            )
+            if isinstance(result, ValidationFeedback):
+                feedback.append(result)
+            else:
+                stored_media.append(result)
+
+        if feedback:
+            self._cleanup(job_id)
+            stored_media = []
+
+        return IngestionResult(stored_media=stored_media, feedback=feedback)
+
+    async def _handle_photo(
+        self, job_id: str, upload: UploadFile
+    ) -> StoredMedia | ValidationFeedback:
+        if upload.content_type not in ALLOWED_IMAGE_TYPES:
+            return ValidationFeedback(
+                code="unsupported_photo_type",
+                message="Upload photos as JPEG, PNG, or WEBP files.",
+                media_type="photo",
+                filename=upload.filename,
+            )
+
+        payload = await upload.read()
+        if len(payload) < settings.INGESTION_MIN_IMAGE_BYTES:
+            return ValidationFeedback(
+                code="photo_too_small",
+                message="This photo is too compressed to assess the job. Please upload a higher-resolution image.",
+                media_type="photo",
+                filename=upload.filename,
+            )
+
+        try:
+            image = Image.open(BytesIO(payload)).convert("L")
+        except Exception:
+            return ValidationFeedback(
+                code="invalid_photo",
+                message="We couldn't read this photo. Please upload it again as a clear image file.",
+                media_type="photo",
+                filename=upload.filename,
+            )
+
+        width, height = image.size
+        if (
+            width < settings.INGESTION_MIN_IMAGE_WIDTH
+            or height < settings.INGESTION_MIN_IMAGE_HEIGHT
+        ):
+            return ValidationFeedback(
+                code="photo_low_resolution",
+                message="The photo resolution is too low. Please retake it so the full work area is visible in high resolution.",
+                media_type="photo",
+                filename=upload.filename,
+            )
+
+        brightness = ImageStat.Stat(image).mean[0]
+        if brightness < settings.INGESTION_MIN_BRIGHTNESS:
+            return ValidationFeedback(
+                code="photo_too_dark",
+                message="I can't make out enough detail because the lighting is too low. Please retake the photo with better lighting and include the full area.",
+                media_type="photo",
+                filename=upload.filename,
+            )
+
+        edge_image = image.filter(ImageFilter.FIND_EDGES)
+        edge_stddev = ImageStat.Stat(edge_image).stddev[0]
+        sharpness = math.sqrt(edge_stddev) * 4
+        if sharpness < settings.INGESTION_MIN_SHARPNESS:
+            return ValidationFeedback(
+                code="photo_too_blurry",
+                message="I can't clearly see the work surface because the photo is blurry. Could you snap another photo from a steadier angle?",
+                media_type="photo",
+                filename=upload.filename,
+            )
+
+        metadata = {
+            "width": width,
+            "height": height,
+            "brightness": round(brightness, 2),
+            "sharpness": round(sharpness, 2),
+        }
+        return self._store_media(
+            job_id=job_id,
+            media_type="photo",
+            upload=upload,
+            payload=payload,
+            metadata=metadata,
+        )
+
+    async def _handle_binary_media(
+        self,
+        *,
+        job_id: str,
+        upload: UploadFile,
+        media_type: str,
+        allowed_types: set[str],
+        min_size: int,
+        too_small_message: str,
+    ) -> StoredMedia | ValidationFeedback:
+        if upload.content_type not in allowed_types:
+            return ValidationFeedback(
+                code=f"unsupported_{media_type}_type",
+                message=f"Unsupported {media_type} format. Please upload a standard file type.",
+                media_type=media_type,
+                filename=upload.filename,
+            )
+
+        payload = await upload.read()
+        if len(payload) < min_size:
+            return ValidationFeedback(
+                code=f"{media_type}_too_small",
+                message=too_small_message,
+                media_type=media_type,
+                filename=upload.filename,
+            )
+
+        return self._store_media(
+            job_id=job_id,
+            media_type=media_type,
+            upload=upload,
+            payload=payload,
+            metadata={"size_bytes": len(payload)},
+        )
+
+    def _store_media(
+        self,
+        *,
+        job_id: str,
+        media_type: str,
+        upload: UploadFile,
+        payload: bytes,
+        metadata: dict[str, float | int | str | bool | None],
+    ) -> StoredMedia:
+        job_dir = self.storage_root / job_id / media_type
+        job_dir.mkdir(parents=True, exist_ok=True)
+        filename = self._safe_filename(upload.filename, media_type)
+        destination = job_dir / filename
+        destination.write_bytes(payload)
+
+        return StoredMedia(
+            media_type=media_type,
+            filename=filename,
+            content_type=upload.content_type or "application/octet-stream",
+            size_bytes=len(payload),
+            storage_path=str(destination),
+            metadata=metadata,
+        )
+
+    def _cleanup(self, job_id: str) -> None:
+        job_dir = self.storage_root / job_id
+        if not job_dir.exists():
+            return
+
+        for path in sorted(job_dir.rglob("*"), reverse=True):
+            if path.is_file():
+                path.unlink()
+            elif path.is_dir():
+                path.rmdir()
+        if job_dir.exists():
+            job_dir.rmdir()
+
+    def _safe_filename(self, original_name: str | None, media_type: str) -> str:
+        suffix = Path(original_name or "").suffix or self._default_extension(media_type)
+        stem = Path(original_name or media_type).stem or media_type
+        sanitized_stem = "".join(char if char.isalnum() or char in {"-", "_"} else "-" for char in stem)
+        return f"{sanitized_stem}-{uuid4().hex[:8]}{suffix.lower()}"
+
+    def _default_extension(self, media_type: str) -> str:
+        return {
+            "photo": ".jpg",
+            "video": ".mp4",
+            "voice": ".m4a",
+        }[media_type]
+
+
+def build_job_payload(
+    *,
+    job_id: str,
+    session_id: str | None,
+    client_reference: str | None,
+    stored_media: list[StoredMedia],
+) -> dict:
+    return {
+        "job_id": job_id,
+        "session_id": session_id,
+        "client_reference": client_reference,
+        "created_at": datetime.now(UTC).isoformat(),
+        "media": [item.model_dump() for item in stored_media],
+        "status": "queued_for_analysis",
+    }
+
+
+media_ingestion_service = MediaIngestionService()

--- a/backend/app/tests/test_ingestion.py
+++ b/backend/app/tests/test_ingestion.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+from PIL import Image
+from fastapi.testclient import TestClient
+
+from app.services.analysis_queue import analysis_queue
+from app.services.media_ingestion import media_ingestion_service
+
+
+def _make_image_bytes(*, brightness: int, size: tuple[int, int], blur: bool) -> bytes:
+    image = Image.new("RGB", size, color=(brightness, brightness, brightness))
+
+    if not blur:
+        for x in range(0, size[0], 40):
+            for y in range(0, size[1], 40):
+                color = (255, 255, 255) if (x // 40 + y // 40) % 2 == 0 else (0, 0, 0)
+                for dx in range(min(20, size[0] - x)):
+                    for dy in range(min(20, size[1] - y)):
+                        image.putpixel((x + dx, y + dy), color)
+
+    output = BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+def test_ingestion_accepts_and_queues_multimodal_payload(client: TestClient):
+    analysis_queue.clear()
+
+    photo = _make_image_bytes(brightness=170, size=(1600, 1200), blur=False)
+    audio = b"voice-note" * 2000
+    video = b"\x00\x00\x00\x20ftypisom" + (b"video-frame" * 60000)
+
+    with client.websocket_connect("/api/v1/ingestion/ws/session-123") as websocket:
+        response = client.post(
+            "/api/v1/ingestion/vision-to-scope",
+            data={"session_id": "session-123", "client_reference": "ISSUE-152"},
+            files=[
+                ("photos", ("beam.png", photo, "image/png")),
+                ("voice_notes", ("walkthrough.m4a", audio, "audio/mp4")),
+                ("videos", ("site.mp4", video, "video/mp4")),
+            ],
+        )
+        websocket_message = websocket.receive_json()
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["status"] == "accepted"
+    assert payload["forwarded_to_queue"] is True
+    assert payload["feedback"] == []
+    assert len(payload["stored_media"]) == 3
+
+    queued_jobs = analysis_queue.snapshot()
+    assert len(queued_jobs) == 1
+    assert queued_jobs[0]["job_id"] == payload["job_id"]
+    assert queued_jobs[0]["client_reference"] == "ISSUE-152"
+    assert websocket_message["payload"]["status"] == "accepted"
+
+    for media in payload["stored_media"]:
+        assert Path(media["storage_path"]).exists()
+
+    analysis_queue.clear()
+    media_ingestion_service._cleanup(payload["job_id"])
+
+
+def test_ingestion_rejects_dark_or_low_quality_media(client: TestClient):
+    analysis_queue.clear()
+
+    dark_photo = _make_image_bytes(brightness=12, size=(1600, 1200), blur=False)
+
+    response = client.post(
+        "/api/v1/ingestion/vision-to-scope",
+        data={"session_id": "session-456"},
+        files=[("photos", ("beam-dark.png", dark_photo, "image/png"))],
+    )
+
+    assert response.status_code == 202
+    payload = response.json()
+    assert payload["status"] == "rejected"
+    assert payload["forwarded_to_queue"] is False
+    assert payload["stored_media"] == []
+    assert any(item["code"] == "photo_too_dark" for item in payload["feedback"])
+    assert analysis_queue.snapshot() == []

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,3 +21,4 @@ aiohttp==3.9.1
 stellar-sdk==13.1.0
 argon2-cffi==23.1.0
 fastapi-mail==1.4.1
+Pillow==10.4.0


### PR DESCRIPTION

## Overview
This PR adds a new multimodal "Vision-to-Scope" backend ingestion flow for photos, videos, and voice notes. It validates uploaded media immediately, rejects low-quality submissions with actionable feedback, stores accepted payloads, and forwards valid jobs to the analysis queue. It also adds a WebSocket channel for real-time validation updates.

## Related Issue
Closes #152

## Changes

### ⚙️ Multimodal Ingestion Endpoint
- **[ADD]** `backend/app/api/v1/endpoints/ingestion.py`
  - Added `POST /api/v1/ingestion/vision-to-scope` to accept multipart photo, video, and voice-note uploads.
  - Added `GET/WS /api/v1/ingestion/ws/{session_id}` support for real-time validation notifications.
  - Returns synchronous validation results and queue-forwarding status.

### 🧠 Media Validation And Storage
- **[ADD]** `backend/app/services/media_ingestion.py`
  - Added media validation for image resolution, brightness, blur/sharpness, supported MIME types, and minimum audio/video size.
  - Rejects sub-standard payloads with actionable feedback messages.
  - Stores accepted media locally under the ingestion storage directory.
  - Builds the payload forwarded to the analysis queue.

- **[MODIFY]** `backend/app/core/config.py`
  - Added configurable ingestion thresholds and storage settings for image, video, and voice validation.

### 📡 Queue And Realtime Feedback
- **[ADD]** `backend/app/services/analysis_queue.py`
  - Added a lightweight analysis queue service for accepted jobs.

- **[ADD]** `backend/app/services/ingestion_realtime.py`
  - Added WebSocket session management for publishing validation events to connected clients.

### 🧾 Schemas And Routing
- **[ADD]** `backend/app/schemas/ingestion.py`
  - Added response, stored-media, and validation-feedback schemas for the ingestion API.

- **[MODIFY]** `backend/app/api/v1/api.py`
  - Registered the new ingestion router.
  - Fixed the missing `stats` router import so the API module loads correctly.

### 🧪 Tests And Dependency Support
- **[ADD]** `backend/app/tests/test_ingestion.py`
  - Added tests for accepted multimodal payloads, queue forwarding, WebSocket notifications, and rejected low-quality media.

- **[MODIFY]** `backend/requirements.txt`
  - Added `Pillow` for image inspection and quality validation.

### 🔧 Blocking Repo Fix
- **[MODIFY]** `backend/app/schemas/user.py`
  - Added the missing `Enum` import so the backend app can import and boot correctly during tests.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Endpoint successfully accepts and stores multimodal payloads | ✅ |
| Sub-standard media is rejected with actionable feedback | ✅ |
| Good payloads are forwarded to the Analysis Node queue | ✅ |
| Validation updates can be delivered through WebSocket | ✅ |

## How to Test

```bash
# 1. Confirm you're on the branch
git branch --show-current

# 2. Move into the backend
cd backend

# 3. Run the targeted backend test slice
DEBUG=False SECRET_KEY=test-secret-key DATABASE_URL=sqlite:///./test.db REQUIRE_EMAIL_VERIFICATION=False .venv314/bin/pytest app/tests/test_ingestion.py app/tests/test_main.py -q

# 4. Optional: inspect the changed files
git diff -- backend/app/api/v1/api.py backend/app/api/v1/endpoints/ingestion.py backend/app/core/config.py backend/app/schemas/ingestion.py backend/app/services/analysis_queue.py backend/app/services/ingestion_realtime.py backend/app/services/media_ingestion.py backend/app/tests/test_ingestion.py backend/app/schemas/user.py backend/requirements.txt
```
