### PR TITLE
fix: Infra: Implement Health Check Monitoring and Alerts

### DIFF
--- a/backend/app/api/v1/endpoints/health.py
+++ b/backend/app/api/v1/endpoints/health.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from app.core.cache import cache
 from app.core.config import settings
 from app.db.session import get_db
 
@@ -9,20 +10,41 @@ router = APIRouter()
 
 
 @router.get("/health")
-def health_check(db: Session = Depends(get_db)):
+async def health_check(response: Response, db: Session = Depends(get_db)):
     """
-    Health check endpoint to verify server and database connectivity.
+    Health check endpoint to verify server, database, and Redis connectivity.
+
+    Returns HTTP 200 when all dependencies are healthy, and HTTP 503 when any
+    dependency is unavailable. Designed to be consumed by external uptime
+    monitors (e.g. UptimeRobot) that trigger email/Slack alerts on failure.
     """
+    # Check database connectivity
     try:
-        # Test database connection
         db.execute(text("SELECT 1"))
         db_status = "healthy"
     except Exception:
         db_status = "unhealthy"
 
+    # Check Redis connectivity
+    try:
+        if cache.redis is None:
+            redis_status = "unhealthy"
+        else:
+            await cache.redis.ping()
+            redis_status = "healthy"
+    except Exception:
+        redis_status = "unhealthy"
+
+    overall_healthy = db_status == "healthy" and redis_status == "healthy"
+    overall_status = "healthy" if overall_healthy else "unhealthy"
+
+    if not overall_healthy:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+
     return {
-        "status": "healthy",
+        "status": overall_status,
         "project": settings.PROJECT_NAME,
         "database": db_status,
+        "redis": redis_status,
         "debug": settings.DEBUG,
     }

--- a/backend/app/docs/health_monitoring.md
+++ b/backend/app/docs/health_monitoring.md
@@ -1,0 +1,71 @@
+# Health Check Monitoring and Alerts
+
+## Endpoint
+
+`GET /api/v1/health`
+
+The endpoint verifies connectivity to all critical runtime dependencies:
+
+- **Database** — executes `SELECT 1` against the primary Postgres connection.
+- **Redis** — issues a `PING` against the configured Redis instance.
+
+### Responses
+
+`200 OK` — every dependency is reachable:
+
+```json
+{
+  "status": "healthy",
+  "project": "Stellarts",
+  "database": "healthy",
+  "redis": "healthy",
+  "debug": false
+}
+```
+
+`503 Service Unavailable` — any dependency is unreachable. The response body
+still includes per-component status so alerts can identify which subsystem
+failed.
+
+## External Uptime Monitor (UptimeRobot)
+
+Configure a monitor with the following settings:
+
+| Field              | Value                                              |
+| ------------------ | -------------------------------------------------- |
+| Monitor Type       | HTTP(s) — Keyword                                  |
+| URL                | `https://api.<your-domain>/api/v1/health`          |
+| Keyword Type       | Exists                                             |
+| Keyword            | `"status":"healthy"`                               |
+| Monitoring Interval| 1 minute                                           |
+| HTTP Method        | GET                                                |
+
+The keyword match ensures the monitor flags downtime when any dependency
+reports `unhealthy`, even if the HTTP status is somehow 200.
+
+Create an equivalent monitor for each RPC node the backend depends on,
+pointing at their respective health/ping endpoints.
+
+## Alert Channels
+
+Under **My Settings → Alert Contacts** in UptimeRobot, configure:
+
+1. **Email** — the on-call distribution list (e.g. `oncall@stellarts.io`).
+2. **Slack** — incoming webhook for the `#alerts-infra` channel. Generate it
+   from Slack's _Incoming Webhooks_ app and paste it into the
+   _Add Alert Contact → Slack_ dialog.
+
+Attach both contacts to every health-check monitor. Recommended thresholds:
+
+- Notify **when down** after 2 consecutive failures.
+- Notify **when back up** immediately.
+- Escalate to PagerDuty (optional) after 5 minutes of continuous downtime.
+
+## Local Verification
+
+```bash
+curl -i http://localhost:8000/api/v1/health
+```
+
+A healthy local stack returns `200` with all components reporting `healthy`.
+Stop Redis or Postgres to confirm the endpoint correctly returns `503`.


### PR DESCRIPTION
## Summary

Expanded the `/api/v1/health` endpoint (`backend/app/api/v1/endpoints/health.py`) to actively verify both database and Redis connectivity:

- Executes `SELECT 1` against the DB session and reports per-component status.
- Issues a `PING` against the async Redis client and reports its status.
- Returns HTTP 503 when any dependency is unreachable (while still emitting a structured JSON body with per-component state) so external monitors can alert accurately.
- Preserves existing fields (`status`, `project`, `debug`) for backward compatibility with existing tests/consumers.

Added `backend/app/docs/health_monitoring.md` documenting the UptimeRobot configuration (HTTP keyword monitor matching `"status":"healthy"`, 1-minute interval) and the email + Slack alert-contact setup required to satisfy the downtime-alerting acceptance criteria.

---

closes #238