### PR TITLE
fix: Security: Implement Rate Limiting for Payment Endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -2,13 +2,22 @@
 import uuid
 from decimal import Decimal
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 from stellar_sdk import TransactionEnvelope
 
 from app.core.auth import require_client
 from app.core.config import settings
+from app.core.rate_limit import (
+    PREPARE_RATE_LIMIT,
+    REFUND_RATE_LIMIT,
+    RELEASE_RATE_LIMIT,
+    SUBMIT_RATE_LIMIT,
+    check_failed_submission_limit,
+    limiter,
+    record_failed_submission,
+)
 from app.db.session import get_db
 from app.models.booking import Booking
 from app.models.user import User
@@ -53,7 +62,9 @@ class RefundRequest(BaseModel):
 
 
 @router.post("/prepare", summary="Prepare unsigned payment XDR for client signing")
+@limiter.limit(PREPARE_RATE_LIMIT)
 def prepare(
+    request: Request,
     req: PrepareRequest,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_client),
@@ -88,11 +99,17 @@ def prepare(
 
 
 @router.post("/submit", summary="Submit signed payment XDR from wallet")
+@limiter.limit(SUBMIT_RATE_LIMIT)
 def submit(
+    request: Request,
     req: SubmitRequest,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_client),
 ):
+    # Tighter throttle for repeated failures — stop spammers early before
+    # we even attempt to parse the XDR or hit the Stellar network.
+    check_failed_submission_limit(request)
+
     # Require verified email before submitting payments (configurable)
     if settings.REQUIRE_EMAIL_VERIFICATION and not current_user.is_verified:
         raise HTTPException(
@@ -113,6 +130,7 @@ def submit(
             memo_text = memo_text.decode()
         booking_token = memo_text.replace("hold-", "")
     except Exception:
+        record_failed_submission(request)
         raise HTTPException(
             status_code=400, detail="Invalid signed transaction XDR"
         ) from None
@@ -128,6 +146,7 @@ def submit(
             if str(row[0]).startswith(booking_token)
         ]
         if len(candidates) != 1:
+            record_failed_submission(request)
             raise HTTPException(
                 status_code=400,
                 detail="Unable to resolve booking from transaction memo",
@@ -138,13 +157,16 @@ def submit(
     try:
         booking_uuid = uuid.UUID(str(booking_id))
     except ValueError:
+        record_failed_submission(request)
         raise HTTPException(status_code=404, detail="Booking not found") from None
 
     booking = db.query(Booking).filter(Booking.id == booking_uuid).first()
     if not booking:
+        record_failed_submission(request)
         raise HTTPException(status_code=404, detail="Booking not found")
 
     if booking.client.user_id != current_user.id:
+        record_failed_submission(request)
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You are not authorized to submit payment for this booking",
@@ -152,21 +174,34 @@ def submit(
 
     res = submit_signed_payment(db, req.signed_xdr)
     if res.get("status") == "error":
+        record_failed_submission(request)
         raise HTTPException(status_code=400, detail=res.get("message"))
     return res
 
 
 @router.post("/release", summary="Release escrow to artisan")
-def release(req: ReleaseRequest, db: Session = Depends(get_db)):
+@limiter.limit(RELEASE_RATE_LIMIT)
+def release(
+    request: Request,
+    req: ReleaseRequest,
+    db: Session = Depends(get_db),
+):
     res = release_payment(db, req.booking_id, req.artisan_public, req.amount)
     if res.get("status") == "error":
+        record_failed_submission(request)
         raise HTTPException(status_code=400, detail=res.get("message"))
     return res
 
 
 @router.post("/refund", summary="Refund escrow to client")
-def refund(req: RefundRequest, db: Session = Depends(get_db)):
+@limiter.limit(REFUND_RATE_LIMIT)
+def refund(
+    request: Request,
+    req: RefundRequest,
+    db: Session = Depends(get_db),
+):
     res = refund_payment(db, req.booking_id, req.client_public, req.amount)
     if res.get("status") == "error":
+        record_failed_submission(request)
         raise HTTPException(status_code=400, detail=res.get("message"))
     return res

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,0 +1,97 @@
+"""Rate limiting utilities for the API.
+
+This module wraps ``slowapi`` to provide a single shared ``Limiter`` instance
+used across the application.  It is primarily applied to the payment
+endpoints (``/prepare``, ``/submit``, ``/release``, ``/refund``) to mitigate
+booking_id brute-forcing and prevent spamming the Stellar network.
+
+Failed submissions (ones that raise ``HTTPException`` after a transaction is
+rejected by the network) are tracked separately with a tighter limit via
+:func:`record_failed_submission` / :func:`check_failed_submission_limit`.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from typing import Deque, Dict
+
+from fastapi import HTTPException, Request, status
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
+
+# Default key function: client IP (falls back to authenticated user if we want
+# to extend later).  Using remote address is sufficient for basic abuse
+# protection on these endpoints.
+limiter = Limiter(key_func=get_remote_address, headers_enabled=False)
+
+
+# Per-endpoint limits.  Kept conservative enough to allow legitimate users
+# to retry a few times while blocking brute-force / spam attacks.
+PREPARE_RATE_LIMIT = "10/minute"
+SUBMIT_RATE_LIMIT = "10/minute"
+RELEASE_RATE_LIMIT = "10/minute"
+REFUND_RATE_LIMIT = "10/minute"
+
+# Tighter limit for *failed* transaction submissions.  If a client produces
+# too many failing submissions in a short window they are temporarily
+# blocked, because each failure still costs Stellar network resources and
+# is a strong signal of abuse.
+FAILED_SUBMISSION_MAX = 3
+FAILED_SUBMISSION_WINDOW_SECONDS = 60
+
+
+_failed_submissions: Dict[str, Deque[float]] = defaultdict(deque)
+
+
+def _prune(dq: Deque[float], window: float) -> None:
+    cutoff = time.monotonic() - window
+    while dq and dq[0] < cutoff:
+        dq.popleft()
+
+
+def check_failed_submission_limit(request: Request) -> None:
+    """Raise ``429`` if the caller has accumulated too many failed submissions.
+
+    Should be called *before* attempting a Stellar submission so that a
+    client that has already failed repeatedly is prevented from generating
+    further load.
+    """
+    key = get_remote_address(request)
+    dq = _failed_submissions[key]
+    _prune(dq, FAILED_SUBMISSION_WINDOW_SECONDS)
+    if len(dq) >= FAILED_SUBMISSION_MAX:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=(
+                "Too many failed payment submissions. "
+                "Please wait before retrying."
+            ),
+        )
+
+
+def record_failed_submission(request: Request) -> None:
+    """Record that this caller just had a failed submission."""
+    key = get_remote_address(request)
+    dq = _failed_submissions[key]
+    _prune(dq, FAILED_SUBMISSION_WINDOW_SECONDS)
+    dq.append(time.monotonic())
+
+
+def reset_failed_submissions() -> None:
+    """Testing helper: clear all tracked failures."""
+    _failed_submissions.clear()
+
+
+__all__ = [
+    "limiter",
+    "RateLimitExceeded",
+    "PREPARE_RATE_LIMIT",
+    "SUBMIT_RATE_LIMIT",
+    "RELEASE_RATE_LIMIT",
+    "REFUND_RATE_LIMIT",
+    "check_failed_submission_limit",
+    "record_failed_submission",
+    "reset_failed_submissions",
+]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,12 +2,16 @@ from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.api.v1.api import api_router
 from app.core.cache import cache
 from app.core.config import settings
+from app.core.rate_limit import limiter
 from app.db.session import get_db
 
 
@@ -26,6 +30,11 @@ app = FastAPI(
     debug=settings.DEBUG,
     lifespan=lifespan,
 )
+
+# Register rate limiter with the app and install middleware + error handler.
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_middleware(SlowAPIMiddleware)
 
 # Set all CORS enabled origins
 if settings.BACKEND_CORS_ORIGINS:

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -17,6 +17,7 @@ os.environ.setdefault("REQUIRE_EMAIL_VERIFICATION", "False")
 
 # Ensure tests run with email verification enforcement disabled by default
 from app.core.config import settings as _settings
+from app.core.rate_limit import limiter, reset_failed_submissions
 from app.db.base import Base
 from app.db.session import get_db
 from app.main import app
@@ -35,6 +36,16 @@ def override_get_db():
         yield db
     finally:
         db.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limits():
+    """Reset in-memory rate limit state between tests so they don't interfere."""
+    limiter.reset()
+    reset_failed_submissions()
+    yield
+    limiter.reset()
+    reset_failed_submissions()
 
 
 @pytest.fixture(scope="function")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,3 +21,4 @@ aiohttp==3.9.1
 stellar-sdk==13.1.0
 argon2-cffi==23.1.0
 fastapi-mail==1.4.1
+slowapi==0.1.9


### PR DESCRIPTION
## Summary

Added rate limiting to the payment endpoints using `slowapi`.

Changes:
- New `app/core/rate_limit.py` module exposing a shared `Limiter` (keyed on remote IP) and a lightweight in-memory tracker for failed Stellar submissions (`check_failed_submission_limit` / `record_failed_submission`).
- Wired the limiter into `app/main.py`: registers `SlowAPIMiddleware`, attaches the limiter to `app.state`, and installs the `RateLimitExceeded` exception handler.
- `app/api/v1/endpoints/payments.py`: `/prepare`, `/submit`, `/release`, and `/refund` now have `@limiter.limit(...)` decorators (10/minute each) and accept a `Request` argument. `/submit` additionally calls `check_failed_submission_limit` before work and `record_failed_submission` on any error path (bad XDR, unresolved booking, auth failure, Stellar submission error), producing a tighter 3-failures-per-minute limit on faulty submissions. `/release` and `/refund` also record failures to throttle spam against the Stellar network.
- `app/tests/conftest.py`: autouse fixture that resets limiter state between tests so rate limits don't leak across tests.
- `requirements.txt`: added `slowapi==0.1.9`.

---

closes #199