### PR TITLE
fix: Backend: Standardize API Error Response Format

### DIFF
--- a/backend/app/core/exception_handlers.py
+++ b/backend/app/core/exception_handlers.py
@@ -1,0 +1,102 @@
+"""
+Global exception handlers for the FastAPI application.
+
+Ensures every error response follows the unified schema:
+    {
+        "error_code": str,
+        "message": str,
+        "details": object
+    }
+"""
+
+from http import HTTPStatus
+from typing import Any
+
+from fastapi import FastAPI, Request, status
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+
+def _error_code_from_status(status_code: int) -> str:
+    try:
+        phrase = HTTPStatus(status_code).phrase
+    except ValueError:
+        return f"HTTP_{status_code}"
+    return phrase.upper().replace(" ", "_").replace("-", "_")
+
+
+def _build_error_response(
+    status_code: int,
+    error_code: str,
+    message: str,
+    details: Any | None = None,
+) -> JSONResponse:
+    if details is None:
+        details_payload: Any = {}
+    elif isinstance(details, dict):
+        details_payload = details
+    else:
+        details_payload = {"info": details}
+
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "error_code": error_code,
+            "message": message,
+            "details": jsonable_encoder(details_payload),
+        },
+    )
+
+
+async def http_exception_handler(
+    request: Request, exc: StarletteHTTPException
+) -> JSONResponse:
+    detail = exc.detail
+    message: str
+    details: Any = {}
+
+    if isinstance(detail, dict):
+        message = str(detail.get("message") or detail.get("msg") or "HTTP error")
+        error_code = str(
+            detail.get("error_code") or _error_code_from_status(exc.status_code)
+        )
+        details = detail.get("details", {k: v for k, v in detail.items()
+                                          if k not in {"message", "msg", "error_code", "details"}})
+    else:
+        message = str(detail) if detail is not None else _error_code_from_status(
+            exc.status_code
+        ).replace("_", " ").title()
+        error_code = _error_code_from_status(exc.status_code)
+
+    return _build_error_response(exc.status_code, error_code, message, details)
+
+
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    return _build_error_response(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        error_code="VALIDATION_ERROR",
+        message="Request validation failed",
+        details={"errors": exc.errors()},
+    )
+
+
+async def unhandled_exception_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    return _build_error_response(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        error_code="INTERNAL_SERVER_ERROR",
+        message="An unexpected error occurred",
+        details={"type": exc.__class__.__name__},
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register global exception handlers on the given FastAPI app."""
+    app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from app.api.v1.api import api_router
 from app.core.cache import cache
 from app.core.config import settings
+from app.core.exception_handlers import register_exception_handlers
 from app.db.session import get_db
 
 
@@ -26,6 +27,9 @@ app = FastAPI(
     debug=settings.DEBUG,
     lifespan=lifespan,
 )
+
+# Register global exception handlers for unified error responses
+register_exception_handlers(app)
 
 # Set all CORS enabled origins
 if settings.BACKEND_CORS_ORIGINS:


### PR DESCRIPTION
## Summary

Added a global exception handling module at `backend/app/core/exception_handlers.py` that registers handlers for `StarletteHTTPException` (covers FastAPI's `HTTPException`), `RequestValidationError`, and generic `Exception`. Every handler returns a JSON response conforming to the unified schema `{ error_code: string, message: string, details: object }`. The handlers are wired into the FastAPI app via `register_exception_handlers(app)` in `backend/app/main.py`. HTTP status phrases are converted into uppercase snake-case `error_code`s (e.g. 404 → `NOT_FOUND`), validation errors use `VALIDATION_ERROR` with the field-level errors in `details`, and unexpected exceptions yield `INTERNAL_SERVER_ERROR`. Structured `HTTPException` details (dicts containing `error_code`/`message`/`details`) are respected so individual endpoints can enrich the response without breaking the contract.

---

closes #208