### PR TITLE
fix: Security: Implement Rate Limiting for Payment Endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -2,13 +2,14 @@
 import uuid
 from decimal import Decimal
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 from stellar_sdk import TransactionEnvelope
 
 from app.core.auth import require_client
 from app.core.config import settings
+from app.core.rate_limit import PAYMENT_FAILURE_LIMIT, PAYMENT_LIMIT, limiter
 from app.db.session import get_db
 from app.models.booking import Booking
 from app.models.user import User
@@ -53,7 +54,9 @@ class RefundRequest(BaseModel):
 
 
 @router.post("/prepare", summary="Prepare unsigned payment XDR for client signing")
+@limiter.limit(PAYMENT_LIMIT)
 def prepare(
+    request: Request,
     req: PrepareRequest,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_client),
@@ -88,7 +91,9 @@ def prepare(
 
 
 @router.post("/submit", summary="Submit signed payment XDR from wallet")
+@limiter.limit(PAYMENT_LIMIT)
 def submit(
+    request: Request,
     req: SubmitRequest,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_client),
@@ -113,6 +118,9 @@ def submit(
             memo_text = memo_text.decode()
         booking_token = memo_text.replace("hold-", "")
     except Exception:
+        # Invalid XDR counts as a failed submission; apply the stricter limit
+        # so attackers can't use this endpoint to probe the Stellar network.
+        _enforce_failure_limit(request)
         raise HTTPException(
             status_code=400, detail="Invalid signed transaction XDR"
         ) from None
@@ -128,6 +136,7 @@ def submit(
             if str(row[0]).startswith(booking_token)
         ]
         if len(candidates) != 1:
+            _enforce_failure_limit(request)
             raise HTTPException(
                 status_code=400,
                 detail="Unable to resolve booking from transaction memo",
@@ -152,12 +161,14 @@ def submit(
 
     res = submit_signed_payment(db, req.signed_xdr)
     if res.get("status") == "error":
+        _enforce_failure_limit(request)
         raise HTTPException(status_code=400, detail=res.get("message"))
     return res
 
 
 @router.post("/release", summary="Release escrow to artisan")
-def release(req: ReleaseRequest, db: Session = Depends(get_db)):
+@limiter.limit(PAYMENT_LIMIT)
+def release(request: Request, req: ReleaseRequest, db: Session = Depends(get_db)):
     res = release_payment(db, req.booking_id, req.artisan_public, req.amount)
     if res.get("status") == "error":
         raise HTTPException(status_code=400, detail=res.get("message"))
@@ -165,8 +176,32 @@ def release(req: ReleaseRequest, db: Session = Depends(get_db)):
 
 
 @router.post("/refund", summary="Refund escrow to client")
-def refund(req: RefundRequest, db: Session = Depends(get_db)):
+@limiter.limit(PAYMENT_LIMIT)
+def refund(request: Request, req: RefundRequest, db: Session = Depends(get_db)):
     res = refund_payment(db, req.booking_id, req.client_public, req.amount)
     if res.get("status") == "error":
         raise HTTPException(status_code=400, detail=res.get("message"))
     return res
+
+
+def _enforce_failure_limit(request: Request) -> None:
+    """Apply a stricter rate limit for failed payment submissions.
+
+    Uses the same underlying ``slowapi`` storage so repeated failures from the
+    same client (invalid XDR or rejected Stellar transactions) quickly trip
+    the ``PAYMENT_FAILURE_LIMIT`` threshold and are rejected with HTTP 429
+    well before the normal ``PAYMENT_LIMIT`` is exhausted.
+    """
+    from limits import parse_many
+
+    key = limiter._key_func(request)
+    scope = "payments:submit:failure"
+    for item in parse_many(PAYMENT_FAILURE_LIMIT):
+        if not limiter._limiter.hit(item, key, scope):
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=(
+                    "Too many failed payment submissions. "
+                    "Please wait before trying again."
+                ),
+            )

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,0 +1,53 @@
+"""Rate limiting configuration for sensitive endpoints.
+
+This module exposes a shared ``Limiter`` instance (powered by ``slowapi``) that
+is used to protect payment-related endpoints from abuse such as brute-forcing
+``booking_id`` values or spamming the Stellar network with failed submissions.
+
+The limiter is keyed by the authenticated user id when available and falls
+back to the remote client address otherwise.
+
+Two classes of limits are exposed:
+
+* :data:`PAYMENT_LIMIT` – normal limit for successful/standard calls to
+  ``/prepare``, ``/submit`` and ``/release``.
+* :data:`PAYMENT_FAILURE_LIMIT` – stricter limit applied on submissions that
+  resulted in a failed Stellar transaction. It is enforced manually by the
+  submit endpoint after a failure, so repeated failing attempts get blocked
+  well before the normal limit is exhausted.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+# Default per-endpoint limit for normal payment flow calls.
+PAYMENT_LIMIT = "10/minute"
+
+# Stricter limit applied to failed /submit calls to avoid spamming the Stellar
+# network with broken/invalid transactions.
+PAYMENT_FAILURE_LIMIT = "3/minute"
+
+
+def _key_func(request: Request) -> str:
+    """Prefer the authenticated user id when present, else fall back to IP."""
+    user = getattr(request.state, "user", None)
+    if user is not None and getattr(user, "id", None) is not None:
+        return f"user:{user.id}"
+    return get_remote_address(request)
+
+
+# Allow disabling the limiter in test/CI environments where repeated calls
+# from the same client would otherwise exhaust the quota.
+_enabled = os.getenv("RATE_LIMIT_ENABLED", "true").lower() not in {
+    "0",
+    "false",
+    "no",
+    "off",
+}
+
+limiter = Limiter(key_func=_key_func, default_limits=[], enabled=_enabled)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,12 +2,16 @@ from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.api.v1.api import api_router
 from app.core.cache import cache
 from app.core.config import settings
+from app.core.rate_limit import limiter
 from app.db.session import get_db
 
 
@@ -26,6 +30,11 @@ app = FastAPI(
     debug=settings.DEBUG,
     lifespan=lifespan,
 )
+
+# Register rate limiter
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_middleware(SlowAPIMiddleware)
 
 # Set all CORS enabled origins
 if settings.BACKEND_CORS_ORIGINS:

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -14,6 +14,9 @@ os.environ.setdefault("SECRET_KEY", "test-secret-key")
 os.environ.setdefault("DATABASE_URL", SQLALCHEMY_DATABASE_URL)
 # Disable email verification enforcement during tests by default
 os.environ.setdefault("REQUIRE_EMAIL_VERIFICATION", "False")
+# Disable rate limiting in tests so repeated calls from the TestClient don't
+# exhaust the per-endpoint quota across tests.
+os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
 
 # Ensure tests run with email verification enforcement disabled by default
 from app.core.config import settings as _settings

--- a/backend/app/tests/test_payments_rate_limit.py
+++ b/backend/app/tests/test_payments_rate_limit.py
@@ -1,0 +1,109 @@
+"""Tests that rate limiting is wired up for payment endpoints."""
+
+from unittest.mock import patch
+
+from app.core import rate_limit as rate_limit_module
+
+
+def test_limiter_is_attached_to_app():
+    """The FastAPI app must expose the slowapi ``Limiter`` as app state."""
+    from app.main import app
+
+    assert getattr(app.state, "limiter", None) is rate_limit_module.limiter
+
+
+def test_payment_endpoints_have_rate_limit_decorator():
+    """Each sensitive payment route must be decorated with ``limiter.limit``.
+
+    We check for the ``_rate_limit`` attribute that ``slowapi`` attaches to the
+    wrapped function so that the decorator cannot be removed silently.
+    """
+    from app.api.v1.endpoints import payments
+
+    for name in ("prepare", "submit", "release"):
+        fn = getattr(payments, name)
+        # slowapi stores the configured limits on the endpoint callable.
+        assert hasattr(fn, "_rate_limit") or hasattr(fn, "__wrapped__"), (
+            f"payments.{name} is missing a slowapi rate-limit decorator"
+        )
+
+
+def test_failure_limit_triggers_429(client, db_session, monkeypatch):
+    """Repeated failed /submit calls should be blocked by the stricter limit."""
+    import uuid
+
+    from app.core.security import create_access_token, get_password_hash
+    from app.models.artisan import Artisan
+    from app.models.booking import Booking
+    from app.models.client import Client
+    from app.models.user import User
+
+    # Re-enable the limiter just for this test
+    original_enabled = rate_limit_module.limiter.enabled
+    rate_limit_module.limiter.enabled = True
+    # Clear any residual counters
+    rate_limit_module.limiter.reset()
+    try:
+        hashed = get_password_hash("Password1!")
+        client_user = User(
+            email=f"ratelimit-{uuid.uuid4().hex[:6]}@example.com",
+            hashed_password=hashed,
+            role="client",
+            is_verified=True,
+        )
+        db_session.add(client_user)
+        db_session.commit()
+        db_session.refresh(client_user)
+
+        artisan_user = User(
+            email=f"rla-{uuid.uuid4().hex[:6]}@example.com",
+            hashed_password=hashed,
+            role="artisan",
+            is_verified=True,
+        )
+        db_session.add(artisan_user)
+        db_session.commit()
+        db_session.refresh(artisan_user)
+
+        artisan = Artisan(user_id=artisan_user.id, business_name="RL")
+        db_session.add(artisan)
+        db_session.commit()
+        db_session.refresh(artisan)
+
+        client_profile = Client(user_id=client_user.id)
+        db_session.add(client_profile)
+        db_session.commit()
+        db_session.refresh(client_profile)
+
+        booking = Booking(
+            client_id=client_profile.id,
+            artisan_id=artisan.id,
+            service="S",
+            estimated_cost=10,
+        )
+        db_session.add(booking)
+        db_session.commit()
+        db_session.refresh(booking)
+
+        token = create_access_token(subject=client_user.id)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Force XDR parsing to always fail so each call hits the failure path
+        with patch(
+            "app.api.v1.endpoints.payments.TransactionEnvelope.from_xdr",
+            side_effect=ValueError("bad xdr"),
+        ):
+            statuses = []
+            # PAYMENT_FAILURE_LIMIT is 3/minute so the 4th call should be 429
+            for _ in range(5):
+                resp = client.post(
+                    "/api/v1/payments/submit",
+                    json={"signed_xdr": "BADXDR"},
+                    headers=headers,
+                )
+                statuses.append(resp.status_code)
+
+        assert 429 in statuses, f"expected a 429 in {statuses}"
+    finally:
+        rate_limit_module.limiter.reset()
+        rate_limit_module.limiter.enabled = original_enabled

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,3 +21,4 @@ aiohttp==3.9.1
 stellar-sdk==13.1.0
 argon2-cffi==23.1.0
 fastapi-mail==1.4.1
+slowapi==0.1.9


### PR DESCRIPTION
## Summary

Added rate limiting to payment endpoints using `slowapi`.

- New `backend/app/core/rate_limit.py` defines a shared `Limiter` keyed by authenticated user id (falling back to remote IP), plus two quota constants: `PAYMENT_LIMIT = "10/minute"` for normal calls and a stricter `PAYMENT_FAILURE_LIMIT = "3/minute"` for failed submissions. Honors a `RATE_LIMIT_ENABLED` env var to disable the limiter in tests/CI.
- `backend/app/main.py` registers the limiter on `app.state`, installs `SlowAPIMiddleware`, and wires `_rate_limit_exceeded_handler` for `RateLimitExceeded`.
- `backend/app/api/v1/endpoints/payments.py` now decorates `/prepare`, `/submit`, `/release`, and `/refund` with `@limiter.limit(PAYMENT_LIMIT)`, adds the required `request: Request` parameter, and calls a new `_enforce_failure_limit` helper on every failure path in `/submit` (invalid XDR, unresolvable memo, or rejected Stellar transaction) so repeated failures trip the stricter `PAYMENT_FAILURE_LIMIT` and return HTTP 429 well before the normal quota is exhausted.
- `backend/requirements.txt` pins `slowapi==0.1.9`.
- `backend/app/tests/conftest.py` sets `RATE_LIMIT_ENABLED=false` so the TestClient's shared IP doesn't exhaust quotas across tests.
- New `backend/app/tests/test_payments_rate_limit.py` verifies the limiter is attached to the app, the payment endpoints carry the decorator, and repeated failing `/submit` calls are blocked with a 429.

---

closes #199