### PR TITLE
fix: Backend: Standardize API Error Response Format

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -1,0 +1,139 @@
+"""
+Unified API error response handling.
+
+Provides a standardized error schema returned by every error response in the
+application:
+
+    {
+        "error_code": "<machine readable code>",
+        "message": "<human readable message>",
+        "details": { ... },
+    }
+
+A legacy ``detail`` field mirroring ``message`` is also included to preserve
+backwards compatibility with existing clients and tests that read the
+FastAPI default ``detail`` key.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+
+class AppError(HTTPException):
+    """Application-level error with an explicit machine-readable error code."""
+
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        error_code: str,
+        details: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(status_code=status_code, detail=message, headers=headers)
+        self.error_code = error_code
+        self.message = message
+        self.details: dict[str, Any] = details or {}
+
+
+def _default_error_code(status_code: int) -> str:
+    try:
+        phrase = HTTPStatus(status_code).phrase
+    except ValueError:
+        return f"HTTP_{status_code}"
+    return phrase.upper().replace(" ", "_").replace("-", "_")
+
+
+def _build_response(
+    status_code: int,
+    error_code: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    payload: dict[str, Any] = {
+        "error_code": error_code,
+        "message": message,
+        "details": details or {},
+        # Legacy field kept for backwards compatibility with existing
+        # clients/tests that read FastAPI's default ``detail`` key.
+        "detail": message,
+    }
+    return JSONResponse(status_code=status_code, content=payload, headers=headers)
+
+
+async def app_error_handler(request: Request, exc: AppError) -> JSONResponse:
+    return _build_response(
+        status_code=exc.status_code,
+        error_code=exc.error_code,
+        message=exc.message,
+        details=exc.details,
+        headers=getattr(exc, "headers", None),
+    )
+
+
+async def http_exception_handler(
+    request: Request, exc: StarletteHTTPException
+) -> JSONResponse:
+    detail = exc.detail
+    details: dict[str, Any] = {}
+    if isinstance(detail, dict):
+        message = str(detail.get("message") or detail.get("detail") or detail)
+        error_code = str(
+            detail.get("error_code") or _default_error_code(exc.status_code)
+        )
+        nested = detail.get("details")
+        if isinstance(nested, dict):
+            details = nested
+    else:
+        message = str(detail) if detail is not None else HTTPStatus(
+            exc.status_code
+        ).phrase
+        error_code = _default_error_code(exc.status_code)
+
+    return _build_response(
+        status_code=exc.status_code,
+        error_code=error_code,
+        message=message,
+        details=details,
+        headers=getattr(exc, "headers", None),
+    )
+
+
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    return _build_response(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        error_code="VALIDATION_ERROR",
+        message="Request validation failed",
+        details={"errors": exc.errors()},
+    )
+
+
+async def unhandled_exception_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    return _build_response(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        error_code="INTERNAL_SERVER_ERROR",
+        message="An unexpected error occurred",
+        details={"type": exc.__class__.__name__},
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Attach the unified error handlers to a FastAPI application."""
+
+    app.add_exception_handler(AppError, app_error_handler)
+    app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+    app.add_exception_handler(HTTPException, http_exception_handler)
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from app.api.v1.api import api_router
 from app.core.cache import cache
 from app.core.config import settings
+from app.core.errors import register_exception_handlers
 from app.db.session import get_db
 
 
@@ -26,6 +27,10 @@ app = FastAPI(
     debug=settings.DEBUG,
     lifespan=lifespan,
 )
+
+# Register unified error handlers so every error response follows the schema:
+#   { "error_code": str, "message": str, "details": object }
+register_exception_handlers(app)
 
 # Set all CORS enabled origins
 if settings.BACKEND_CORS_ORIGINS:

--- a/backend/app/tests/test_error_schema.py
+++ b/backend/app/tests/test_error_schema.py
@@ -1,0 +1,87 @@
+"""Tests for the unified API error response schema."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.errors import AppError, register_exception_handlers
+
+
+def _assert_unified_schema(body: dict) -> None:
+    assert "error_code" in body
+    assert "message" in body
+    assert "details" in body
+    assert isinstance(body["error_code"], str)
+    assert isinstance(body["message"], str)
+    assert isinstance(body["details"], dict)
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    register_exception_handlers(app)
+
+    from fastapi import HTTPException
+
+    @app.get("/http-error")
+    def _http_error() -> None:
+        raise HTTPException(status_code=404, detail="Thing not found")
+
+    @app.get("/app-error")
+    def _app_error() -> None:
+        raise AppError(
+            status_code=400,
+            message="Invalid payload",
+            error_code="INVALID_PAYLOAD",
+            details={"field": "email"},
+        )
+
+    @app.get("/validation-error/{num}")
+    def _validation_error(num: int) -> int:
+        return num
+
+    @app.get("/crash")
+    def _crash() -> None:
+        raise RuntimeError("boom")
+
+    return app
+
+
+def test_http_exception_returns_unified_schema() -> None:
+    client = TestClient(_build_app(), raise_server_exceptions=False)
+    resp = client.get("/http-error")
+    assert resp.status_code == 404
+    body = resp.json()
+    _assert_unified_schema(body)
+    assert body["error_code"] == "NOT_FOUND"
+    assert body["message"] == "Thing not found"
+
+
+def test_app_error_returns_custom_code_and_details() -> None:
+    client = TestClient(_build_app(), raise_server_exceptions=False)
+    resp = client.get("/app-error")
+    assert resp.status_code == 400
+    body = resp.json()
+    _assert_unified_schema(body)
+    assert body["error_code"] == "INVALID_PAYLOAD"
+    assert body["message"] == "Invalid payload"
+    assert body["details"] == {"field": "email"}
+
+
+def test_validation_error_returns_unified_schema() -> None:
+    client = TestClient(_build_app(), raise_server_exceptions=False)
+    resp = client.get("/validation-error/not-an-int")
+    assert resp.status_code == 422
+    body = resp.json()
+    _assert_unified_schema(body)
+    assert body["error_code"] == "VALIDATION_ERROR"
+    assert "errors" in body["details"]
+
+
+def test_unhandled_exception_returns_unified_schema() -> None:
+    client = TestClient(_build_app(), raise_server_exceptions=False)
+    resp = client.get("/crash")
+    assert resp.status_code == 500
+    body = resp.json()
+    _assert_unified_schema(body)
+    assert body["error_code"] == "INTERNAL_SERVER_ERROR"


### PR DESCRIPTION
## Summary

Added a unified API error response schema for the FastAPI backend.

- New module `backend/app/core/errors.py` providing:
  - `AppError` HTTPException subclass carrying `error_code`, `message`, and `details`.
  - Global exception handlers for `AppError`, `HTTPException` / Starlette `HTTPException`, `RequestValidationError`, and unhandled `Exception`s.
  - `register_exception_handlers(app)` that wires them into a FastAPI app.
  - All handlers return JSON `{ "error_code": str, "message": str, "details": object }`, plus a legacy `detail` field mirroring `message` for backwards compatibility with existing clients/tests.
- `backend/app/main.py` now calls `register_exception_handlers(app)` so every error raised anywhere in the app conforms to the new schema.
- Added `backend/app/tests/test_error_schema.py` covering the four handler paths (HTTP errors, custom `AppError`, validation errors, unhandled exceptions).

---

closes #208