### PR TITLE
fix: Security: Implement Rate Limiting for Payment Endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -2,13 +2,22 @@
 import uuid
 from decimal import Decimal
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 from stellar_sdk import TransactionEnvelope
 
 from app.core.auth import require_client
 from app.core.config import settings
+from app.core.rate_limit import (
+    PREPARE_RATE_LIMIT,
+    REFUND_RATE_LIMIT,
+    RELEASE_RATE_LIMIT,
+    SUBMIT_RATE_LIMIT,
+    check_failed_submit_quota,
+    limiter,
+    record_failed_submit,
+)
 from app.db.session import get_db
 from app.models.booking import Booking
 from app.models.user import User
@@ -53,7 +62,9 @@ class RefundRequest(BaseModel):
 
 
 @router.post("/prepare", summary="Prepare unsigned payment XDR for client signing")
+@limiter.limit(PREPARE_RATE_LIMIT)
 def prepare(
+    request: Request,
     req: PrepareRequest,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_client),
@@ -88,11 +99,17 @@ def prepare(
 
 
 @router.post("/submit", summary="Submit signed payment XDR from wallet")
+@limiter.limit(SUBMIT_RATE_LIMIT)
 def submit(
+    request: Request,
     req: SubmitRequest,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_client),
 ):
+    # Enforce a stricter quota on *failed* submissions to prevent spamming
+    # the Stellar network with invalid transactions.
+    check_failed_submit_quota(request)
+
     # Require verified email before submitting payments (configurable)
     if settings.REQUIRE_EMAIL_VERIFICATION and not current_user.is_verified:
         raise HTTPException(
@@ -113,6 +130,7 @@ def submit(
             memo_text = memo_text.decode()
         booking_token = memo_text.replace("hold-", "")
     except Exception:
+        record_failed_submit(request)
         raise HTTPException(
             status_code=400, detail="Invalid signed transaction XDR"
         ) from None
@@ -128,6 +146,7 @@ def submit(
             if str(row[0]).startswith(booking_token)
         ]
         if len(candidates) != 1:
+            record_failed_submit(request)
             raise HTTPException(
                 status_code=400,
                 detail="Unable to resolve booking from transaction memo",
@@ -138,13 +157,16 @@ def submit(
     try:
         booking_uuid = uuid.UUID(str(booking_id))
     except ValueError:
+        record_failed_submit(request)
         raise HTTPException(status_code=404, detail="Booking not found") from None
 
     booking = db.query(Booking).filter(Booking.id == booking_uuid).first()
     if not booking:
+        record_failed_submit(request)
         raise HTTPException(status_code=404, detail="Booking not found")
 
     if booking.client.user_id != current_user.id:
+        record_failed_submit(request)
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You are not authorized to submit payment for this booking",
@@ -152,12 +174,14 @@ def submit(
 
     res = submit_signed_payment(db, req.signed_xdr)
     if res.get("status") == "error":
+        record_failed_submit(request)
         raise HTTPException(status_code=400, detail=res.get("message"))
     return res
 
 
 @router.post("/release", summary="Release escrow to artisan")
-def release(req: ReleaseRequest, db: Session = Depends(get_db)):
+@limiter.limit(RELEASE_RATE_LIMIT)
+def release(request: Request, req: ReleaseRequest, db: Session = Depends(get_db)):
     res = release_payment(db, req.booking_id, req.artisan_public, req.amount)
     if res.get("status") == "error":
         raise HTTPException(status_code=400, detail=res.get("message"))
@@ -165,7 +189,8 @@ def release(req: ReleaseRequest, db: Session = Depends(get_db)):
 
 
 @router.post("/refund", summary="Refund escrow to client")
-def refund(req: RefundRequest, db: Session = Depends(get_db)):
+@limiter.limit(REFUND_RATE_LIMIT)
+def refund(request: Request, req: RefundRequest, db: Session = Depends(get_db)):
     res = refund_payment(db, req.booking_id, req.client_public, req.amount)
     if res.get("status") == "error":
         raise HTTPException(status_code=400, detail=res.get("message"))

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -26,6 +26,18 @@ class Settings(BaseSettings):
     REDIS_DB: int = 0
     NEARBY_CACHE_TTL: int = 60  # Seconds to cache nearby-artisan search results
 
+    # Rate limiting (slowapi syntax, e.g. "5/minute").  Lower thresholds are
+    # used for /submit and especially for *failed* /submit attempts to avoid
+    # spamming the Stellar network with bogus transactions.
+    RATE_LIMIT_PAYMENTS_PREPARE: str = "10/minute"
+    RATE_LIMIT_PAYMENTS_SUBMIT: str = "5/minute"
+    RATE_LIMIT_PAYMENTS_SUBMIT_FAILED: str = "3/minute"
+    RATE_LIMIT_PAYMENTS_RELEASE: str = "5/minute"
+    RATE_LIMIT_PAYMENTS_REFUND: str = "5/minute"
+    # Storage backend for slowapi counters.  None => in-process memory (default).
+    # Set to a redis://... URL to share limits across workers.
+    RATE_LIMIT_STORAGE_URI: str | None = None
+
     # CORS
     BACKEND_CORS_ORIGINS: list[AnyHttpUrl] = []
 

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,0 +1,114 @@
+"""Rate limiting configuration for the API.
+
+Uses `slowapi` (a starlette/FastAPI-friendly wrapper around `limits`) to apply
+per-endpoint request rate limits.  The limiter key is derived from the
+authenticated user (via the Authorization header) when present, falling back to
+the remote IP address.  This prevents both anonymous IP-level abuse and
+per-token brute-forcing of protected resources such as `booking_id`.
+
+Configured limits intentionally use lower thresholds for failed `/submit`
+attempts, where each failure spams the Stellar network.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request, status
+from limits import parse
+from limits.storage import storage_from_string
+from limits.strategies import MovingWindowRateLimiter
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from app.core.config import settings
+
+
+def _rate_limit_key(request: Request) -> str:
+    """Return a per-client identifier used to bucket rate limits.
+
+    Prefers the bearer token (so a single attacker cannot trivially bypass by
+    rotating source IPs) and falls back to the remote address.
+    """
+    auth = request.headers.get("authorization") or request.headers.get("Authorization")
+    if auth and auth.lower().startswith("bearer "):
+        return auth.split(" ", 1)[1].strip()
+    return get_remote_address(request)
+
+
+# --- Payment endpoint limits -------------------------------------------------
+# These strings use slowapi/limits syntax, e.g. "10/minute".  They are kept as
+# module-level constants so tests and other modules can reference them.
+PREPARE_RATE_LIMIT = getattr(settings, "RATE_LIMIT_PAYMENTS_PREPARE", "10/minute")
+SUBMIT_RATE_LIMIT = getattr(settings, "RATE_LIMIT_PAYMENTS_SUBMIT", "5/minute")
+SUBMIT_FAILED_RATE_LIMIT = getattr(
+    settings, "RATE_LIMIT_PAYMENTS_SUBMIT_FAILED", "3/minute"
+)
+RELEASE_RATE_LIMIT = getattr(settings, "RATE_LIMIT_PAYMENTS_RELEASE", "5/minute")
+REFUND_RATE_LIMIT = getattr(settings, "RATE_LIMIT_PAYMENTS_REFUND", "5/minute")
+
+
+# Storage backing for rate-limit counters.  Defaults to in-process memory,
+# which is fine for single-worker deployments and tests.  To share limits
+# across multiple worker processes, set RATE_LIMIT_STORAGE_URI (e.g. to the
+# application's Redis URL).
+_storage_uri = getattr(settings, "RATE_LIMIT_STORAGE_URI", None) or "memory://"
+
+# `headers_enabled` is left at its default (False) because the application
+# mounts `SlowAPIMiddleware`, which handles RateLimit-* response headers.
+limiter = Limiter(
+    key_func=_rate_limit_key,
+    storage_uri=_storage_uri,
+    default_limits=[],
+)
+
+
+# Separate, lower-level bucket used to track *failed* /submit attempts.
+# slowapi's decorator only counts the request itself, so we maintain a
+# parallel window here that we manually bump when a submission fails.
+try:
+    _failed_storage = storage_from_string(_storage_uri)
+except Exception:
+    _failed_storage = storage_from_string("memory://")
+
+_failed_strategy = MovingWindowRateLimiter(_failed_storage)
+_failed_submit_item = parse(SUBMIT_FAILED_RATE_LIMIT)
+
+
+def _failed_submit_bucket(request: Request) -> str:
+    return f"failed-submit:{_rate_limit_key(request)}"
+
+
+def check_failed_submit_quota(request: Request) -> None:
+    """Raise HTTP 429 if this client has exhausted the failed-submit quota.
+
+    Does not consume the quota; call `record_failed_submit` after an attempt
+    fails to actually decrement the bucket.
+    """
+    try:
+        allowed = _failed_strategy.test(
+            _failed_submit_item, _failed_submit_bucket(request)
+        )
+    except Exception:
+        # If the storage backend is unavailable, fail open rather than denying
+        # legitimate traffic.  The primary /submit slowapi limit still applies.
+        return
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=(
+                "Too many failed payment submissions. Please wait before "
+                "retrying."
+            ),
+        )
+
+
+def record_failed_submit(request: Request) -> None:
+    """Consume one slot in the failed-submit quota.
+
+    Called after a `/submit` call is rejected so repeated failures quickly
+    exhaust the stricter limit independently of successful traffic.  Errors
+    here are swallowed so rate-limit bookkeeping can never crash a request.
+    """
+    try:
+        _failed_strategy.hit(_failed_submit_item, _failed_submit_bucket(request))
+    except Exception:
+        pass

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,12 +2,16 @@ from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.api.v1.api import api_router
 from app.core.cache import cache
 from app.core.config import settings
+from app.core.rate_limit import limiter
 from app.db.session import get_db
 
 
@@ -26,6 +30,11 @@ app = FastAPI(
     debug=settings.DEBUG,
     lifespan=lifespan,
 )
+
+# Register the rate limiter with the app
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_middleware(SlowAPIMiddleware)
 
 # Set all CORS enabled origins
 if settings.BACKEND_CORS_ORIGINS:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,3 +21,4 @@ aiohttp==3.9.1
 stellar-sdk==13.1.0
 argon2-cffi==23.1.0
 fastapi-mail==1.4.1
+slowapi==0.1.9


### PR DESCRIPTION
## Summary

Added per-endpoint rate limiting to the payment API using `slowapi`.

- New module `app/core/rate_limit.py` defines a shared `Limiter` whose key function prefers the bearer token over the remote IP (so brute-forcing `booking_id`s can't be bypassed by rotating source addresses). The same module also maintains a separate, stricter moving-window bucket for *failed* `/submit` attempts (`check_failed_submit_quota` / `record_failed_submit`), which is hit whenever a submission is rejected (invalid XDR, unknown booking, ownership mismatch, Stellar error) so repeated failures exhaust a tighter quota without affecting successful traffic.
- `app/api/v1/endpoints/payments.py` decorates `/prepare`, `/submit`, `/release` and `/refund` with `@limiter.limit(...)`, accepts the `Request` parameter required by slowapi, and wires the failed-submit bookkeeping into `/submit`.
- `app/main.py` registers the limiter on `app.state`, installs `SlowAPIMiddleware`, and adds the `RateLimitExceeded → 429` exception handler.
- `app/core/config.py` exposes configurable limits (`RATE_LIMIT_PAYMENTS_PREPARE`, `…_SUBMIT`, `…_SUBMIT_FAILED`, `…_RELEASE`, `…_REFUND`) with sensible defaults (10/min for `/prepare`, 5/min for the others, 3/min for failed submits) plus an optional `RATE_LIMIT_STORAGE_URI` for sharing counters across workers via Redis. Storage defaults to in-process memory and falls back to it if the configured backend is unreachable, so rate-limit bookkeeping never breaks a request.
- `slowapi` added to `backend/requirements.txt`.

---

closes #199