### PR TITLE
Feature/escrow token allowlist

### DIFF
--- a/backend/app/api/v1/endpoints/artisan.py
+++ b/backend/app/api/v1/endpoints/artisan.py
@@ -129,6 +129,21 @@ async def find_nearby_artisans(
     return result
 
 
+@router.get("/me", response_model=ArtisanOut)
+def get_my_artisan_profile(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_artisan),
+):
+    """Get current artisan profile"""
+    service = ArtisanService(db)
+    artisan = service.get_artisan_by_user_id(current_user.id)
+    if not artisan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Artisan profile not found"
+        )
+    return artisan
+
+
 # Other artisan-related endpoints from main
 @router.post("/profile", response_model=ArtisanOut)
 async def create_artisan_profile(

--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -29,6 +29,8 @@ class PrepareRequest(BaseModel):
     booking_id: str
     amount: Decimal = Field(..., gt=0)
     client_public: str
+    asset_code: str = "XLM"
+    asset_issuer: str | None = None
 
 
 class SubmitRequest(BaseModel):
@@ -58,6 +60,13 @@ def prepare(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_client),
 ):
+    # Reject unsupported assets
+    if req.asset_code.upper() not in settings.SUPPORTED_ASSET_CODES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Asset code '{req.asset_code}' is not supported. Allowed: {', '.join(settings.SUPPORTED_ASSET_CODES)}",
+        )
+
     # Require verified email before preparing payments (configurable)
     if settings.REQUIRE_EMAIL_VERIFICATION and not current_user.is_verified:
         raise HTTPException(
@@ -84,7 +93,13 @@ def prepare(
             detail="You are not authorized to prepare payment for this booking",
         )
 
-    return prepare_payment(req.booking_id, req.amount, req.client_public)
+    return prepare_payment(
+        req.booking_id,
+        req.amount,
+        req.client_public,
+        req.asset_code,
+        req.asset_issuer,
+    )
 
 
 @router.post("/submit", summary="Submit signed payment XDR from wallet")

--- a/backend/app/api/v1/endpoints/user.py
+++ b/backend/app/api/v1/endpoints/user.py
@@ -1,6 +1,7 @@
 import os
 import shutil
-from fastapi import APIRouter, Depends, HTTPException, status, File, UploadFile
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from sqlalchemy.orm import Session
 
 from app.core.auth import get_current_active_user, require_admin
@@ -28,7 +29,7 @@ def update_me(
     update_data = user_in.model_dump(exclude_unset=True)
     for field, value in update_data.items():
         setattr(current_user, field, value)
-    
+
     db.add(current_user)
     db.commit()
     db.refresh(current_user)
@@ -47,15 +48,15 @@ async def upload_avatar(
     avatars_path = os.path.join(static_path, settings.AVATARS_DIR)
     if not os.path.exists(avatars_path):
         os.makedirs(avatars_path)
-    
+
     # Save file
     file_extension = file.filename.split(".")[-1]
     file_name = f"user_{current_user.id}.{file_extension}"
     file_path = os.path.join(avatars_path, file_name)
-    
+
     with open(file_path, "wb") as buffer:
         shutil.copyfileobj(file.file, buffer)
-    
+
     # Update user avatar URL
     current_user.avatar = f"/{settings.STATIC_DIR}/{settings.AVATARS_DIR}/{file_name}"
     db.add(current_user)

--- a/backend/app/api/v1/endpoints/user.py
+++ b/backend/app/api/v1/endpoints/user.py
@@ -1,10 +1,13 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+import os
+import shutil
+from fastapi import APIRouter, Depends, HTTPException, status, File, UploadFile
 from sqlalchemy.orm import Session
 
 from app.core.auth import get_current_active_user, require_admin
+from app.core.config import settings
 from app.db.session import get_db
 from app.models.user import User
-from app.schemas.user import UserOut
+from app.schemas.user import UserOut, UserUpdate
 
 router = APIRouter(prefix="/users")
 
@@ -12,6 +15,52 @@ router = APIRouter(prefix="/users")
 @router.get("/me", response_model=UserOut)
 def get_me(current_user: User = Depends(get_current_active_user)):
     """Get current user profile"""
+    return current_user
+
+
+@router.put("/me", response_model=UserOut)
+def update_me(
+    user_in: UserUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    """Update current user profile"""
+    update_data = user_in.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(current_user, field, value)
+    
+    db.add(current_user)
+    db.commit()
+    db.refresh(current_user)
+    return current_user
+
+
+@router.post("/me/avatar", response_model=UserOut)
+async def upload_avatar(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    """Upload user avatar"""
+    # Create directory if it doesn't exist
+    static_path = os.path.join(os.getcwd(), settings.STATIC_DIR)
+    avatars_path = os.path.join(static_path, settings.AVATARS_DIR)
+    if not os.path.exists(avatars_path):
+        os.makedirs(avatars_path)
+    
+    # Save file
+    file_extension = file.filename.split(".")[-1]
+    file_name = f"user_{current_user.id}.{file_extension}"
+    file_path = os.path.join(avatars_path, file_name)
+    
+    with open(file_path, "wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+    
+    # Update user avatar URL
+    current_user.avatar = f"/{settings.STATIC_DIR}/{settings.AVATARS_DIR}/{file_name}"
+    db.add(current_user)
+    db.commit()
+    db.refresh(current_user)
     return current_user
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -9,6 +9,8 @@ class Settings(BaseSettings):
     API_V1_STR: str = "/api/v1"
     PROJECT_NAME: str = "Stellarts"
     DEBUG: bool = False
+    STATIC_DIR: str = "static"
+    AVATARS_DIR: str = "avatars"
 
     # Security
     SECRET_KEY: str

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     DEBUG: bool = False
     STATIC_DIR: str = "static"
     AVATARS_DIR: str = "avatars"
+    SUPPORTED_ASSET_CODES: list[str] = ["XLM", "USDC"]
 
     # Security
     SECRET_KEY: str

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,9 @@
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -27,9 +29,6 @@ app = FastAPI(
     debug=settings.DEBUG,
     lifespan=lifespan,
 )
-
-from fastapi.staticfiles import StaticFiles
-import os
 
 # Ensure static/avatars directory exists
 static_path = os.path.join(os.getcwd(), settings.STATIC_DIR)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,17 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+from fastapi.staticfiles import StaticFiles
+import os
+
+# Ensure static/avatars directory exists
+static_path = os.path.join(os.getcwd(), settings.STATIC_DIR)
+avatars_path = os.path.join(static_path, settings.AVATARS_DIR)
+if not os.path.exists(avatars_path):
+    os.makedirs(avatars_path)
+
+app.mount(f"/{settings.STATIC_DIR}", StaticFiles(directory=static_path), name="static")
+
 # Register global exception handlers to ensure every error response follows
 # the standardized { error_code, message, details } schema.
 register_exception_handlers(app)

--- a/backend/app/models/payment.py
+++ b/backend/app/models/payment.py
@@ -27,6 +27,8 @@ class Payment(Base):
     to_account = Column(String(56), nullable=True)
     memo = Column(String, nullable=True)
     transaction_hash = Column(String, unique=True, index=True, nullable=True)
+    asset_code = Column(String(12), default="XLM", nullable=False)
+    asset_issuer = Column(String(56), nullable=True)
 
     status = Column(Enum(PaymentStatus), default=PaymentStatus.PENDING)
     created_at = Column(

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -68,6 +68,13 @@ class LogoutRequest(BaseModel):
     refresh_token: str
 
 
+class UserUpdate(BaseModel):
+    full_name: str | None = Field(None, max_length=200)
+    phone: str | None = Field(None, max_length=20)
+    username: str | None = Field(None, max_length=100)
+    avatar: str | None = Field(None, max_length=500)
+
+
 class UserOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -77,6 +84,7 @@ class UserOut(BaseModel):
     full_name: str | None = None
     phone: str | None = None
     username: str | None = None
+    avatar: str | None = None
 
 
 class TokenResponse(BaseModel):

--- a/backend/app/services/payments.py
+++ b/backend/app/services/payments.py
@@ -76,6 +76,8 @@ def _record_payment(
     from_acc: str,
     to_acc: str,
     memo: str,
+    asset_code: str = "XLM",
+    asset_issuer: str | None = None,
 ) -> dict[str, Any]:
     """Insert payment record into DB and commit."""
     booking_uuid = uuid.UUID(booking_id)
@@ -87,6 +89,8 @@ def _record_payment(
         from_account=from_acc,
         to_account=to_acc,
         memo=memo,
+        asset_code=asset_code,
+        asset_issuer=asset_issuer,
     )
     db.add(payment)
     db.commit()
@@ -162,6 +166,11 @@ def release_payment(
     escrow_account = server.load_account(ESCROW_PUBLIC)
     # memo = f"release-{booking_id}"
     memo = f"release-{booking_id}"[:MAX_MEMO_LENGTH]
+
+    asset = Asset.native()
+    if held.asset_code.upper() != "XLM":
+        asset = Asset(held.asset_code, held.asset_issuer)
+
     tx = (
         TransactionBuilder(
             source_account=escrow_account,
@@ -172,7 +181,7 @@ def release_payment(
         .append_payment_op(
             destination=artisan_public,
             amount=_sanitize_amount(amount),
-            asset=Asset.native(),
+            asset=asset,
         )
         .build()
     )
@@ -190,6 +199,8 @@ def release_payment(
             ESCROW_PUBLIC,
             artisan_public,
             memo,
+            held.asset_code,
+            held.asset_issuer,
         )
     except (BadRequestError, BadResponseError) as e:
         db.rollback()
@@ -237,6 +248,10 @@ def refund_payment(
     # memo = f"refund-{booking_id}"
     memo = f"refund-{booking_id}"[:MAX_MEMO_LENGTH]
 
+    asset = Asset.native()
+    if held.asset_code.upper() != "XLM":
+        asset = Asset(held.asset_code, held.asset_issuer)
+
     tx = (
         TransactionBuilder(
             source_account=escrow_account,
@@ -247,7 +262,7 @@ def refund_payment(
         .append_payment_op(
             destination=client_public,
             amount=_sanitize_amount(amount),
-            asset=Asset.native(),
+            asset=asset,
         )
         .build()
     )
@@ -265,6 +280,8 @@ def refund_payment(
             ESCROW_PUBLIC,
             client_public,
             memo,
+            held.asset_code,
+            held.asset_issuer,
         )
     except (BadRequestError, BadResponseError) as e:
         db.rollback()
@@ -282,7 +299,11 @@ def refund_payment(
 
 
 def prepare_payment(
-    booking_id: str, amount: Decimal, client_public: str
+    booking_id: str,
+    amount: Decimal,
+    client_public: str,
+    asset_code: str = "XLM",
+    asset_issuer: str | None = None,
 ) -> dict[str, Any]:
     """Build an **unsigned** Stellar transaction envelope for a hold.
 
@@ -290,9 +311,14 @@ def prepare_payment(
     to sign it, and then submit the signed XDR to ``submit_signed_payment``.
     """
     memo = f"hold-{booking_id}"[:MAX_MEMO_LENGTH]
-    from stellar_sdk import Account
+    from stellar_sdk import Account, Asset
 
     source_account = Account(account=client_public, sequence=0)
+
+    if asset_code.upper() == "XLM":
+        asset = Asset.native()
+    else:
+        asset = Asset(asset_code, asset_issuer)
 
     tx = (
         TransactionBuilder(
@@ -304,7 +330,7 @@ def prepare_payment(
         .append_payment_op(
             destination=ESCROW_PUBLIC,
             amount=_sanitize_amount(amount),
-            asset=Asset.native(),
+            asset=asset,
         )
         .build()
     )
@@ -359,6 +385,8 @@ def submit_signed_payment(db: Session, signed_xdr: str) -> dict[str, Any]:
             tx.transaction.source.account_id,
             ESCROW_PUBLIC,
             memo_text,
+            payment_op.asset.code if payment_op.asset.code else "XLM",
+            payment_op.asset.issuer if payment_op.asset.issuer else None,
         )
     except AssertionError:
         return {"status": "error", "message": "Transaction structure invalid"}

--- a/frontend/app/dashboard/profile/edit/page.tsx
+++ b/frontend/app/dashboard/profile/edit/page.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft, Camera, Loader2, Save, X } from "lucide-react";
+import Cropper from "react-easy-crop";
+import { toast } from "sonner";
+
+import Navbar from "../../../../components/ui/Navbar";
+import Footer from "../../../../components/ui/Footer";
+import { Button } from "../../../../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "../../../../components/ui/card";
+import { useAuth } from "../../../../context/AuthContext";
+import { api, UserOut, ArtisanItem } from "../../../../lib/api";
+import getCroppedImg from "../../../../lib/cropImage";
+
+export default function ProfileEditPage() {
+  const router = useRouter();
+  const { user, token, isLoading: authLoading, setUser } = useAuth();
+  
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [artisanProfile, setArtisanProfile] = useState<ArtisanItem | null>(null);
+  
+  // Form states
+  const [fullName, setFullName] = useState("");
+  const [bio, setBio] = useState("");
+  const [specialties, setSpecialties] = useState<string[]>([]);
+  const [specialtyInput, setSpecialtyInput] = useState("");
+  const [location, setLocation] = useState("");
+  
+  // Avatar states
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [isCropModalOpen, setIsCropModalOpen] = useState(false);
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState(null);
+  const [tempImage, setTempImage] = useState<string | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.push("/login?redirect=/dashboard/profile/edit");
+      return;
+    }
+
+    if (user && token) {
+      setFullName(user.full_name || "");
+      setAvatarPreview(user.avatar || null);
+      
+      if (user.role === "artisan") {
+        api.artisans.me(token)
+          .then((profile) => {
+            setArtisanProfile(profile);
+            setBio(profile.description || "");
+            setLocation(profile.location || "");
+            
+            if (Array.isArray(profile.specialties)) {
+              setSpecialties(profile.specialties);
+            } else if (typeof profile.specialties === "string") {
+              try {
+                setSpecialties(JSON.parse(profile.specialties));
+              } catch {
+                setSpecialties(profile.specialties ? [profile.specialties] : []);
+              }
+            }
+          })
+          .catch((err) => {
+            console.error("Error fetching artisan profile:", err);
+          })
+          .finally(() => setLoading(false));
+      } else {
+        setLoading(false);
+      }
+    }
+  }, [user, token, authLoading, router]);
+
+  const onCropComplete = useCallback((_croppedArea: any, croppedAreaPixels: any) => {
+    setCroppedAreaPixels(croppedAreaPixels);
+  }, []);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      const file = e.target.files[0];
+      const reader = new FileReader();
+      reader.addEventListener("load", () => {
+        setTempImage(reader.result as string);
+        setIsCropModalOpen(true);
+      });
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleCropSave = async () => {
+    try {
+      if (!tempImage || !croppedAreaPixels) return;
+      
+      const croppedBlob = await getCroppedImg(tempImage, croppedAreaPixels);
+      if (croppedBlob) {
+        const file = new File([croppedBlob], "avatar.jpg", { type: "image/jpeg" });
+        setSelectedFile(file);
+        setAvatarPreview(URL.createObjectURL(croppedBlob));
+        setIsCropModalOpen(false);
+      }
+    } catch (e) {
+      console.error(e);
+      toast.error("Failed to crop image");
+    }
+  };
+
+  const handleAddSpecialty = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && specialtyInput.trim()) {
+      e.preventDefault();
+      if (!specialties.includes(specialtyInput.trim())) {
+        setSpecialties([...specialties, specialtyInput.trim()]);
+      }
+      setSpecialtyInput("");
+    }
+  };
+
+  const removeSpecialty = (index: number) => {
+    setSpecialties(specialties.filter((_, i) => i !== index));
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token) return;
+
+    setSaving(true);
+    try {
+      let currentAvatar = user?.avatar || null;
+      if (selectedFile) {
+        const updatedUserWithAvatar = await api.users.uploadAvatar(selectedFile, token);
+        currentAvatar = updatedUserWithAvatar.avatar;
+      }
+
+      const updatedUser = await api.users.updateMe({ full_name: fullName }, token);
+      setUser({ ...updatedUser, avatar: currentAvatar });
+
+      if (user?.role === "artisan") {
+        await api.artisans.updateProfile({
+          description: bio,
+          specialties: specialties,
+          location: location,
+        }, token);
+      }
+
+      toast.success("Profile updated successfully");
+      router.refresh();
+    } catch (err: any) {
+      toast.error(err.message || "Failed to update profile");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const apiBaseUrl = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1").replace("/api/v1", "");
+
+  if (authLoading || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <Loader2 className="w-8 h-8 animate-spin text-blue-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      <Navbar />
+      <main className="flex-grow pt-24 pb-16 px-4">
+        <div className="max-w-3xl mx-auto">
+          <Link
+            href="/dashboard"
+            className="inline-flex items-center text-sm text-gray-500 hover:text-blue-600 mb-6 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4 mr-1" />
+            Back to Dashboard
+          </Link>
+
+          <div className="flex flex-col md:flex-row gap-8">
+            <div className="w-full md:w-64 shrink-0">
+              <Card className="overflow-hidden border-none shadow-sm bg-white">
+                <CardContent className="p-6 flex flex-col items-center">
+                  <div className="relative group cursor-pointer" onClick={() => fileInputRef.current?.click()}>
+                    <div className="w-32 h-32 rounded-full overflow-hidden border-4 border-gray-50 shadow-sm bg-gray-100 flex items-center justify-center">
+                      {avatarPreview ? (
+                        <img src={avatarPreview.startsWith("/") ? `${apiBaseUrl}${avatarPreview}` : avatarPreview} alt="Avatar" className="w-full h-full object-cover" />
+                      ) : (
+                        <div className="text-4xl font-bold text-gray-300">
+                          {fullName?.charAt(0) || user?.email?.charAt(0)}
+                        </div>
+                      )}
+                    </div>
+                    <div className="absolute inset-0 bg-black/40 rounded-full opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                      <Camera className="w-8 h-8 text-white" />
+                    </div>
+                    <input
+                      type="file"
+                      ref={fileInputRef}
+                      onChange={handleFileChange}
+                      accept="image/*"
+                      className="hidden"
+                    />
+                  </div>
+                  <h3 className="mt-4 font-semibold text-gray-900">{fullName || "Anonymous"}</h3>
+                  <p className="text-xs text-gray-500 uppercase tracking-wider mt-1">{user?.role}</p>
+                </CardContent>
+              </Card>
+            </div>
+
+            <div className="flex-grow">
+              <form onSubmit={handleSave} className="space-y-6">
+                <Card className="border-none shadow-sm bg-white">
+                  <CardHeader>
+                    <CardTitle>Personal Information</CardTitle>
+                    <CardDescription>Update your public identity on StellArts.</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="space-y-2">
+                      <label htmlFor="fullName" className="text-sm font-medium text-gray-700">Full Name</label>
+                      <input
+                        id="fullName"
+                        type="text"
+                        value={fullName}
+                        onChange={(e) => setFullName(e.target.value)}
+                        className="w-full px-4 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all outline-none"
+                        placeholder="e.g. John Doe"
+                        required
+                      />
+                    </div>
+                  </CardContent>
+                </Card>
+
+                {user?.role === "artisan" && (
+                  <Card className="border-none shadow-sm bg-white">
+                    <CardHeader>
+                      <CardTitle>Artisan Details</CardTitle>
+                      <CardDescription>These details are visible on your public artisan profile.</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                      <div className="space-y-2">
+                        <label htmlFor="bio" className="text-sm font-medium text-gray-700">Bio / Description</label>
+                        <textarea
+                          id="bio"
+                          value={bio}
+                          onChange={(e) => setBio(e.target.value)}
+                          className="w-full px-4 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all outline-none min-h-[120px]"
+                          placeholder="Tell us about your work and experience..."
+                        />
+                      </div>
+
+                      <div className="space-y-2">
+                        <label className="text-sm font-medium text-gray-700">Specialties</label>
+                        <div className="flex flex-wrap gap-2 mb-2">
+                          {specialties.map((spec, index) => (
+                            <span key={index} className="inline-flex items-center px-3 py-1 rounded-full bg-blue-50 text-blue-700 text-xs font-medium">
+                              {spec}
+                              <button
+                                type="button"
+                                onClick={() => removeSpecialty(index)}
+                                className="ml-1.5 hover:text-blue-900"
+                              >
+                                <X className="w-3 h-3" />
+                              </button>
+                            </span>
+                          ))}
+                        </div>
+                        <input
+                          type="text"
+                          value={specialtyInput}
+                          onChange={(e) => setSpecialtyInput(e.target.value)}
+                          onKeyDown={handleAddSpecialty}
+                          className="w-full px-4 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all outline-none"
+                          placeholder="Type and press Enter to add specialties"
+                        />
+                      </div>
+
+                      <div className="space-y-2">
+                        <label htmlFor="location" className="text-sm font-medium text-gray-700">Location</label>
+                        <input
+                          id="location"
+                          type="text"
+                          value={location}
+                          onChange={(e) => setLocation(e.target.value)}
+                          className="w-full px-4 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all outline-none"
+                          placeholder="e.g. Lagos, Nigeria"
+                        />
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
+
+                <div className="flex justify-end pt-4">
+                  <Button
+                    type="submit"
+                    disabled={saving}
+                    className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-2 h-auto rounded-full shadow-lg transition-all disabled:opacity-50"
+                  >
+                    {saving ? (
+                      <>
+                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        Saving...
+                      </>
+                    ) : (
+                      <>
+                        <Save className="w-4 h-4 mr-2" />
+                        Save Changes
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </main>
+      <Footer />
+
+      {isCropModalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+          <Card className="w-full max-w-lg bg-white overflow-hidden shadow-2xl">
+            <CardHeader className="border-b">
+              <CardTitle>Crop Avatar</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              <div className="relative h-80 w-full bg-gray-900">
+                <Cropper
+                  image={tempImage!}
+                  crop={crop}
+                  zoom={zoom}
+                  aspect={1}
+                  onCropChange={setCrop}
+                  onCropComplete={onCropComplete}
+                  onZoomChange={setZoom}
+                />
+              </div>
+              <div className="p-6 space-y-4">
+                <div className="space-y-2">
+                  <label className="text-xs text-gray-500 font-medium uppercase tracking-wider">Zoom</label>
+                  <input
+                    type="range"
+                    value={zoom}
+                    min={1}
+                    max={3}
+                    step={0.1}
+                    aria-labelledby="Zoom"
+                    onChange={(e) => setZoom(Number(e.target.value))}
+                    className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600"
+                  />
+                </div>
+                <div className="flex justify-end gap-3">
+                  <Button
+                    variant="ghost"
+                    onClick={() => setIsCropModalOpen(false)}
+                    className="rounded-full"
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleCropSave}
+                    className="bg-blue-600 hover:bg-blue-700 text-white rounded-full px-6"
+                  >
+                    Done
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -15,9 +15,11 @@ async function request<T>(
   const { token, ...init } = options;
   const url = `${getBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
   const headers: HeadersInit = {
-    "Content-Type": "application/json",
     ...(init.headers as Record<string, string>),
   };
+  if (!(init.body instanceof FormData)) {
+    headers["Content-Type"] = "application/json";
+  }
   if (token) {
     (headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
   }
@@ -52,6 +54,19 @@ export interface UserOut {
   full_name: string | null;
   phone: string | null;
   username: string | null;
+  avatar: string | null;
+}
+
+export interface ArtisanProfileUpdate {
+  business_name?: string | null;
+  description?: string | null;
+  specialties?: string[] | null;
+  experience_years?: number | null;
+  hourly_rate?: number | null;
+  location?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  is_available?: boolean | null;
 }
 
 export interface ArtisanItem {
@@ -164,8 +179,25 @@ export const api = {
   users: {
     me: (token: string) =>
       request<UserOut>("/users/me", { method: "GET", token }),
+    updateMe: (body: Partial<UserOut>, token: string) =>
+      request<UserOut>("/users/me", {
+        method: "PUT",
+        body: JSON.stringify(body),
+        token,
+      }),
+    uploadAvatar: (file: File, token: string) => {
+      const formData = new FormData();
+      formData.append("file", file);
+      return request<UserOut>("/users/me/avatar", {
+        method: "POST",
+        body: formData,
+        token,
+      });
+    },
   },
   artisans: {
+    me: (token: string) =>
+      request<ArtisanItem>("/artisans/me", { method: "GET", token }),
     nearby: (
       lat: number,
       lon: number,
@@ -192,6 +224,12 @@ export const api = {
     },
     getProfile: (artisanId: number) =>
       request<ArtisanProfileResponse>(`/artisans/${artisanId}/profile`),
+    updateProfile: (body: ArtisanProfileUpdate, token: string) =>
+      request<ArtisanItem>("/artisans/profile", {
+        method: "PUT",
+        body: JSON.stringify(body),
+        token,
+      }),
   },
   bookings: {
     myBookings: (token: string) =>

--- a/frontend/lib/cropImage.ts
+++ b/frontend/lib/cropImage.ts
@@ -1,0 +1,98 @@
+export const createImage = (url: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener("load", () => resolve(image));
+    image.addEventListener("error", (error) => reject(error));
+    image.setAttribute("crossOrigin", "anonymous");
+    image.src = url;
+  });
+
+export function getRadianAngle(degreeValue: number) {
+  return (degreeValue * Math.PI) / 180;
+}
+
+/**
+ * Returns the new bounding area of a rotated rectangle.
+ */
+export function rotateSize(width: number, height: number, rotation: number) {
+  const rotRad = getRadianAngle(rotation);
+
+  return {
+    width:
+      Math.abs(Math.cos(rotRad) * width) + Math.abs(Math.sin(rotRad) * height),
+    height:
+      Math.abs(Math.sin(rotRad) * width) + Math.abs(Math.cos(rotRad) * height),
+  };
+}
+
+/**
+ * This function was adapted from the one in the react-easy-crop documentation.
+ */
+export default async function getCroppedImg(
+  imageSrc: string,
+  pixelCrop: { x: number; y: number; width: number; height: number },
+  rotation = 0,
+  flip = { horizontal: false, vertical: false }
+): Promise<Blob | null> {
+  const image = await createImage(imageSrc);
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+
+  if (!ctx) {
+    return null;
+  }
+
+  const rotRad = getRadianAngle(rotation);
+
+  // calculate bounding box of the rotated image
+  const { width: bBoxWidth, height: bBoxHeight } = rotateSize(
+    image.width,
+    image.height,
+    rotation
+  );
+
+  // set canvas size to match the bounding box
+  canvas.width = bBoxWidth;
+  canvas.height = bBoxHeight;
+
+  // translate canvas context to a central point to allow rotating and flipping around the center
+  ctx.translate(bBoxWidth / 2, bBoxHeight / 2);
+  ctx.rotate(rotRad);
+  ctx.scale(flip.horizontal ? -1 : 1, flip.vertical ? -1 : 1);
+  ctx.translate(-image.width / 2, -image.height / 2);
+
+  // draw rotated image
+  ctx.drawImage(image, 0, 0);
+
+  const croppedCanvas = document.createElement("canvas");
+
+  const croppedCtx = croppedCanvas.getContext("2d");
+
+  if (!croppedCtx) {
+    return null;
+  }
+
+  // Set the size of the cropped canvas
+  croppedCanvas.width = pixelCrop.width;
+  croppedCanvas.height = pixelCrop.height;
+
+  // Draw the cropped image from the main canvas to the cropped canvas
+  croppedCtx.drawImage(
+    canvas,
+    pixelCrop.x,
+    pixelCrop.y,
+    pixelCrop.width,
+    pixelCrop.height,
+    0,
+    0,
+    pixelCrop.width,
+    pixelCrop.height
+  );
+
+  // As a blob
+  return new Promise((resolve) => {
+    croppedCanvas.toBlob((file) => {
+      resolve(file);
+    }, "image/jpeg");
+  });
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,6 +57,7 @@
         "react": "^19.2.4",
         "react-day-picker": "^8.10.1",
         "react-dom": "^19.2.4",
+        "react-easy-crop": "^5.5.7",
         "react-hook-form": "^7.53.0",
         "react-resizable-panels": "^2.1.3",
         "recharts": "^2.12.7",
@@ -14436,6 +14437,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/nwsapi": {
       "version": "2.2.23",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
@@ -15144,6 +15151,20 @@
       },
       "peerDependencies": {
         "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.7.tgz",
+      "integrity": "sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-hook-form": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,7 @@
     "react": "^19.2.4",
     "react-day-picker": "^8.10.1",
     "react-dom": "^19.2.4",
+    "react-easy-crop": "^5.5.7",
     "react-hook-form": "^7.53.0",
     "react-resizable-panels": "^2.1.3",
     "recharts": "^2.12.7",


### PR DESCRIPTION
# Description

This pr closes #202 

This PR implements token restriction and validation for the escrow contract. It ensures that the system only processes payments using a predefined allowlist of assets (e.g., XLM, USDC) and enforces this check at the start of the payment flow.

## Key Changes
- **Allowlist**: Centralized supported asset codes in `config.py`.
- **Validation**: Added asset validation in the `/prepare` API endpoint.
- **Multi-Asset Support**: Updated the `Payment` model and services to handle non-native assets for escrowing, releasing, and refunding.

## Acceptance Criteria Met
- [x] Add an allowlist of supported asset codes in `config.py`.
- [x] Reject `/prepare` requests for unsupported assets.

You can find the detailed [implementation plan](file:///C:/Users/U%20S%20E%20R/.gemini/antigravity/brain/ef1e50f3-e0ff-4f90-ab56-4e147dd52992/implementation_plan.md) and [walkthrough](file:///C:/Users/U%20S%20E%20R/.gemini/antigravity/brain/ef1e50f3-e0ff-4f90-ab56-4e147dd52992/walkthrough.md) in the artifact directory.