### PR TITLE
#239 Docs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI
+
+# Metadata for your tags to make the UI look professional
+tags_metadata = [
+    {
+        "name": "users",
+        "description": "Operations with users. The **login** logic is also here.",
+    },
+    {
+        "name": "items",
+        "description": "Manage items. So _fancy_ they have their own docs.",
+    },
+]
+
+app = FastAPI(
+    title="StellArts API",
+    description="A public API with full Swagger documentation.",
+    version="1.0.0",
+    openapi_tags=tags_metadata,
+    # Acceptance Criteria: Host at /api/docs
+    docs_url="/api/docs", 
+    # Optional: You can also move the schema logic to match
+    openapi_url="/api/openapi.json",
+    redoc_url="/api/redoc"
+)
+
+

--- a/nft.py
+++ b/nft.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+
+# This goes under src/schemas/nft.py
+class NFTBase(BaseModel):
+    name: str = Field(..., examples=["Galactic Explorer #001"])
+    description: Optional[str] = Field(None, examples=["A rare digital artifact from the Stellar system."])
+
+class NFTCreate(NFTBase):
+    # Data required only during creation
+    image_url: str = Field(..., examples=["https://ipfs.io/ipfs/Qm..."])
+
+class NFTRead(NFTBase):
+    # Data returned to the user (including the database ID)
+    id: int
+    owner_id: str = Field(..., examples=["GABC...123"])
+
+    class Config:
+        from_attributes = True # Allows Pydantic to read data from database models

--- a/user.py
+++ b/user.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, Field
+
+class Item(BaseModel):
+    name: str = Field(examples=["Fubotoy"])
+    price: float = Field(description="The price must be greater than zero", examples=[19.99])
+
+@app.post("/items/", tags=["items"], summary="Create a new item")
+async def create_item(item: Item):
+    """
+    Create an item with all the information:
+    - **name**: each item must have a name
+    - **price**: must be a float
+    """
+    return item


### PR DESCRIPTION
Close: #239 Docs: API Documentation with OpenAPI/Swagger

The current API is documented only in code. We should generate a public Swagger UI.

Acceptance Criteria:

    Ensure all FastAPI endpoints have proper tags, descriptions, and examples.
    Host the docs at /api/docs and ensure they stay up-to-date with code changes.