### PR TITLE
Feature/advanced filters

### DIFF
--- a/backend/app/api/v1/endpoints/artisan.py
+++ b/backend/app/api/v1/endpoints/artisan.py
@@ -81,10 +81,11 @@ async def get_nearby_artisans(
     radius_km: float = Query(
         25.0, ge=0, le=200, description="Search radius in kilometers"
     ),
-    skill: str
-    | None = Query(None, description="Filter by skill keyword (e.g., plumber)"),
-    min_rating: float
-    | None = Query(None, ge=0, le=5, description="Minimum average rating"),
+    skills: list[str] | None = Query(None, description="Filter by skill keywords (e.g., plumber)"),
+    min_rating: float | None = Query(None, ge=0, le=5, description="Minimum average rating"),
+    min_experience: int | None = Query(None, ge=0, description="Minimum experience years"),
+    min_rate: float | None = Query(None, ge=0, description="Minimum hourly rate"),
+    max_rate: float | None = Query(None, ge=0, description="Maximum hourly rate"),
     available: bool | None = Query(None, description="Filter by current availability"),
     page: int = Query(1, ge=1),
     page_size: int = Query(10, ge=1, le=100),
@@ -97,8 +98,11 @@ async def get_nearby_artisans(
         latitude=lat,
         longitude=lon,
         radius_km=radius_km,
-        specialties=[skill] if skill else None,
+        specialties=skills,
         min_rating=min_rating,
+        min_experience_years=min_experience,
+        min_rate=min_rate,
+        max_rate=max_rate,
         is_available=available if available is not None else True,
         limit=page_size * page,  # Fetch enough for pagination
     )

--- a/backend/app/schemas/artisan.py
+++ b/backend/app/schemas/artisan.py
@@ -166,6 +166,15 @@ class NearbyArtisansRequest(BaseModel):
     min_rating: float | None = Field(
         None, ge=0, le=5, description="Minimum rating filter"
     )
+    min_experience_years: int | None = Field(
+        None, ge=0, description="Minimum experience years"
+    )
+    min_rate: float | None = Field(
+        None, ge=0, description="Minimum hourly rate"
+    )
+    max_rate: float | None = Field(
+        None, ge=0, description="Maximum hourly rate"
+    )
     is_available: bool | None = Field(True, description="Filter by availability")
     limit: int | None = Field(20, ge=1, le=100, description="Maximum number of results")
 

--- a/backend/app/services/artisan.py
+++ b/backend/app/services/artisan.py
@@ -231,6 +231,15 @@ class ArtisanService:
             if request.min_rating is not None:
                 query = query.filter(Artisan.rating >= request.min_rating)
 
+            if request.min_experience_years is not None:
+                query = query.filter(Artisan.experience_years >= request.min_experience_years)
+
+            if request.min_rate is not None:
+                query = query.filter(Artisan.hourly_rate >= request.min_rate)
+
+            if request.max_rate is not None:
+                query = query.filter(Artisan.hourly_rate <= request.max_rate)
+
             if request.is_available is not None:
                 query = query.filter(Artisan.is_available == request.is_available)
 

--- a/backend/app/services/artisan_service.py
+++ b/backend/app/services/artisan_service.py
@@ -19,6 +19,9 @@ def _build_cache_key(request: NearbyArtisansRequest) -> str:
         "radius": request.radius_km,
         "specialties": sorted(request.specialties or []),  # order-independent
         "min_rating": request.min_rating,
+        "min_experience_years": request.min_experience_years,
+        "min_rate": request.min_rate,
+        "max_rate": request.max_rate,
         "available": request.is_available,
         "limit": request.limit,
     }

--- a/frontend/app/artisans/page.tsx
+++ b/frontend/app/artisans/page.tsx
@@ -193,21 +193,24 @@ export default function ArtisansPage() {
   const pageSize = 12;
 
   // Filters
-  const [skill, setSkill] = useState("");
+  const [skills, setSkills] = useState<string[]>([]);
   const [minRating, setMinRating] = useState<number>(0);
+  const [minExperience, setMinExperience] = useState<number>(0);
+  const [minRate, setMinRate] = useState<number>(0);
+  const [maxRate, setMaxRate] = useState<number>(500);
   const [isAvailable, setIsAvailable] = useState<boolean>(false);
   const [isFilterDrawerOpen, setIsFilterDrawerOpen] = useState(false);
 
   // Debounced filters
-  const [debouncedFilters, setDebouncedFilters] = useState({ skill, minRating, isAvailable });
+  const [debouncedFilters, setDebouncedFilters] = useState({ skills, minRating, minExperience, minRate, maxRate, isAvailable });
 
   useEffect(() => {
     const handler = setTimeout(() => {
-      setDebouncedFilters({ skill, minRating, isAvailable });
+      setDebouncedFilters({ skills, minRating, minExperience, minRate, maxRate, isAvailable });
       setPage(1); // reset to page 1 on filter
     }, 500);
     return () => clearTimeout(handler);
-  }, [skill, minRating, isAvailable]);
+  }, [skills, minRating, minExperience, minRate, maxRate, isAvailable]);
 
   const requestLocation = () => {
     if (typeof window === "undefined" || !navigator.geolocation) {
@@ -245,8 +248,11 @@ export default function ArtisansPage() {
       .nearby(lat, lon, { 
         page, 
         page_size: pageSize,
-        skill: debouncedFilters.skill || undefined,
+        skills: debouncedFilters.skills.length > 0 ? debouncedFilters.skills : undefined,
         min_rating: debouncedFilters.minRating || undefined,
+        min_experience: debouncedFilters.minExperience || undefined,
+        min_rate: debouncedFilters.minRate || undefined,
+        max_rate: debouncedFilters.maxRate < 500 ? debouncedFilters.maxRate : undefined,
         is_available: debouncedFilters.isAvailable ? true : undefined,
       })
       .then((res) => {
@@ -268,9 +274,18 @@ export default function ArtisansPage() {
   }, [lat, lon, page, debouncedFilters]);
 
   const clearFilters = () => {
-    setSkill("");
+    setSkills([]);
     setMinRating(0);
+    setMinExperience(0);
+    setMinRate(0);
+    setMaxRate(500);
     setIsAvailable(false);
+  };
+
+  const SPECIALTIES = ["Plumber", "Electrician", "Carpenter", "Painter", "Mechanic"];
+  
+  const toggleSkill = (s: string) => {
+    setSkills(prev => prev.includes(s) ? prev.filter(x => x !== s) : [...prev, s]);
   };
 
   const hasLoadedResults = artisans.length > 0 || total > 0;
@@ -294,58 +309,66 @@ export default function ArtisansPage() {
            </div>
         )}
 
-        {/* Desktop Filter Bar */}
-        <div className="hidden md:flex bg-gray-50 p-6 rounded-xl mb-8 flex-row gap-6 items-end border border-gray-100 shadow-sm">
-          <div className="flex-1 min-w-[200px]">
-             <label className="block text-sm font-medium text-gray-700 mb-1">Specialty</label>
-             <select 
-               value={skill} 
-               onChange={(e) => setSkill(e.target.value)}
-               className="w-full rounded-md border border-gray-300 px-3 py-2.5 text-gray-900 focus:border-blue-600 focus:outline-none bg-white transition-all hover:border-gray-400"
-             >
-               <option value="">Any Specialty</option>
-               <option value="Plumber">Plumber</option>
-               <option value="Electrician">Electrician</option>
-               <option value="Carpenter">Carpenter</option>
-               <option value="Painter">Painter</option>
-               <option value="Mechanic">Mechanic</option>
-             </select>
-          </div>
-          <div className="flex-1 min-w-[200px]">
-             <label className="block text-sm font-medium text-gray-700 mb-3">
-               Min Rating ({minRating} Stars)
-             </label>
-             <input 
-               type="range"
-               min="0"
-               max="5"
-               step="1"
-               value={minRating}
-               onChange={(e) => setMinRating(Number(e.target.value))}
-               className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600"
-             />
-          </div>
-          <div className="flex items-center gap-3 h-10 pb-1">
-             <input 
-               type="checkbox"
-               id="availableNow"
-               checked={isAvailable}
-               onChange={(e) => setIsAvailable(e.target.checked)}
-               className="w-5 h-5 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 cursor-pointer"
-             />
-             <label htmlFor="availableNow" className="text-sm font-medium text-gray-700 select-none cursor-pointer">
-               Available Now
-             </label>
-          </div>
-          <Button 
-            variant="outline" 
-            size="sm" 
-            onClick={clearFilters}
-            className="h-10 text-gray-500 hover:text-red-600"
-          >
-            Reset
-          </Button>
-        </div>
+        {/* Main Content Layout */}
+        <div className="flex flex-col md:flex-row gap-8">
+          {/* Desktop Filter Sidebar */}
+          <aside className="hidden md:block w-72 shrink-0">
+            <div className="bg-gray-50 p-6 rounded-xl border border-gray-100 shadow-sm sticky top-28">
+              <h3 className="text-lg font-bold text-gray-900 mb-6 flex items-center justify-between">
+                Filters
+                <Button variant="ghost" size="sm" onClick={clearFilters} className="text-xs text-gray-500 hover:text-red-600 h-auto p-1">Reset</Button>
+              </h3>
+              
+              <div className="space-y-6">
+                <div>
+                  <label className="block text-sm font-semibold text-gray-700 mb-3">Specialties</label>
+                  <div className="flex flex-wrap gap-2">
+                    {SPECIALTIES.map(s => (
+                      <button 
+                        key={s}
+                        onClick={() => toggleSkill(s)}
+                        className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${skills.includes(s) ? 'bg-blue-600 text-white shadow-sm' : 'bg-white text-gray-600 border border-gray-200 hover:border-blue-300'}`}
+                      >
+                        {s}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-semibold text-gray-700 mb-3">
+                    Min Rating ({minRating} Stars)
+                  </label>
+                  <input type="range" min="0" max="5" step="1" value={minRating} onChange={(e) => setMinRating(Number(e.target.value))} className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600" />
+                </div>
+                
+                <div>
+                  <label className="block text-sm font-semibold text-gray-700 mb-3">
+                    Min Experience ({minExperience} yrs)
+                  </label>
+                  <input type="range" min="0" max="30" step="1" value={minExperience} onChange={(e) => setMinExperience(Number(e.target.value))} className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600" />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-semibold text-gray-700 mb-3">
+                    Price Range (${minRate} - ${maxRate === 500 ? '500+' : maxRate})
+                  </label>
+                  <div className="flex items-center gap-2">
+                    <input type="number" value={minRate} onChange={(e) => setMinRate(Number(e.target.value))} className="w-full px-2 py-1.5 text-sm rounded border border-gray-300" placeholder="Min" min="0" />
+                    <span className="text-gray-500">-</span>
+                    <input type="number" value={maxRate} onChange={(e) => setMaxRate(Number(e.target.value))} className="w-full px-2 py-1.5 text-sm rounded border border-gray-300" placeholder="Max" min="0" />
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-3 pt-2">
+                  <input type="checkbox" id="availableNow" checked={isAvailable} onChange={(e) => setIsAvailable(e.target.checked)} className="w-5 h-5 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 cursor-pointer" />
+                  <label htmlFor="availableNow" className="text-sm font-medium text-gray-700 select-none cursor-pointer">Available Now</label>
+                </div>
+              </div>
+            </div>
+          </aside>
+
+          <div className="flex-1 min-w-0">
 
         {/* Mobile Filter Button */}
         <div className="md:hidden flex justify-between items-center mb-6">
@@ -355,7 +378,7 @@ export default function ArtisansPage() {
             className="flex items-center gap-2 bg-white border-gray-200 text-gray-700 shadow-sm"
           >
             <SlidersHorizontal className="w-4 h-4" />
-            Filters {(skill || minRating > 0 || isAvailable) && <span className="flex w-2 h-2 rounded-full bg-blue-600"></span>}
+            Filters {(skills.length > 0 || minRating > 0 || minExperience > 0 || minRate > 0 || maxRate < 500 || isAvailable) && <span className="flex w-2 h-2 rounded-full bg-blue-600"></span>}
           </Button>
           <p className="text-sm text-gray-500">
             {total} results
@@ -380,43 +403,44 @@ export default function ArtisansPage() {
                 </button>
               </div>
 
-              <div className="space-y-6 pb-8">
+              <div className="space-y-6 pb-8 max-h-[60vh] overflow-y-auto px-1">
                 <div>
-                  <label className="block text-sm font-semibold text-gray-700 mb-2">Specialty</label>
-                  <select 
-                    value={skill} 
-                    onChange={(e) => setSkill(e.target.value)}
-                    className="w-full rounded-xl border border-gray-200 px-4 py-3 text-gray-900 focus:border-blue-600 focus:outline-none bg-gray-50"
-                  >
-                    <option value="">Any Specialty</option>
-                    <option value="Plumber">Plumber</option>
-                    <option value="Electrician">Electrician</option>
-                    <option value="Carpenter">Carpenter</option>
-                    <option value="Painter">Painter</option>
-                    <option value="Mechanic">Mechanic</option>
-                  </select>
+                  <label className="block text-sm font-semibold text-gray-700 mb-3">Specialties</label>
+                  <div className="flex flex-wrap gap-2">
+                    {SPECIALTIES.map(s => (
+                      <button 
+                        key={s}
+                        onClick={() => toggleSkill(s)}
+                        className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${skills.includes(s) ? 'bg-blue-600 text-white shadow-sm' : 'bg-gray-50 text-gray-600 border border-gray-200 hover:border-blue-300'}`}
+                      >
+                        {s}
+                      </button>
+                    ))}
+                  </div>
                 </div>
 
                 <div>
                   <label className="block text-sm font-semibold text-gray-700 mb-4">
                     Min Rating ({minRating} Stars)
                   </label>
-                  <input 
-                    type="range"
-                    min="0"
-                    max="5"
-                    step="1"
-                    value={minRating}
-                    onChange={(e) => setMinRating(Number(e.target.value))}
-                    className="w-full h-2 bg-gray-100 rounded-lg appearance-none cursor-pointer accent-blue-600"
-                  />
-                  <div className="flex justify-between mt-2 text-xs text-gray-400 font-medium px-1">
-                    <span>0</span>
-                    <span>1</span>
-                    <span>2</span>
-                    <span>3</span>
-                    <span>4</span>
-                    <span>5</span>
+                  <input type="range" min="0" max="5" step="1" value={minRating} onChange={(e) => setMinRating(Number(e.target.value))} className="w-full h-2 bg-gray-100 rounded-lg appearance-none cursor-pointer accent-blue-600" />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-semibold text-gray-700 mb-4">
+                    Min Experience ({minExperience} yrs)
+                  </label>
+                  <input type="range" min="0" max="30" step="1" value={minExperience} onChange={(e) => setMinExperience(Number(e.target.value))} className="w-full h-2 bg-gray-100 rounded-lg appearance-none cursor-pointer accent-blue-600" />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-semibold text-gray-700 mb-3">
+                    Price Range (${minRate} - ${maxRate === 500 ? '500+' : maxRate})
+                  </label>
+                  <div className="flex items-center gap-2">
+                    <input type="number" value={minRate} onChange={(e) => setMinRate(Number(e.target.value))} className="w-full px-3 py-2 text-sm rounded-lg border border-gray-200 bg-gray-50" placeholder="Min" min="0" />
+                    <span className="text-gray-500">-</span>
+                    <input type="number" value={maxRate} onChange={(e) => setMaxRate(Number(e.target.value))} className="w-full px-3 py-2 text-sm rounded-lg border border-gray-200 bg-gray-50" placeholder="Max" min="0" />
                   </div>
                 </div>
 
@@ -589,6 +613,8 @@ export default function ArtisansPage() {
             )}
           </>
         )}
+          </div>
+        </div>
       </main>
       <Footer />
     </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -149,7 +149,16 @@ export const api = {
     nearby: (
       lat: number,
       lon: number,
-      opts: { page?: number; page_size?: number; skill?: string; min_rating?: number; is_available?: boolean } = {}
+      opts: { 
+        page?: number; 
+        page_size?: number; 
+        skills?: string[]; 
+        min_rating?: number; 
+        min_experience?: number;
+        min_rate?: number;
+        max_rate?: number;
+        is_available?: boolean;
+      } = {}
     ) => {
       const params = new URLSearchParams({
         lat: String(lat),
@@ -157,9 +166,14 @@ export const api = {
         page: String(opts.page ?? 1),
         page_size: String(opts.page_size ?? 10),
       });
-      if (opts.skill) params.append("skill", opts.skill);
+      if (opts.skills && opts.skills.length > 0) {
+        opts.skills.forEach(skill => params.append("skills", skill));
+      }
       if (opts.min_rating !== undefined && opts.min_rating > 0) params.append("min_rating", String(opts.min_rating));
-      if (opts.is_available !== undefined) params.append("is_available", String(opts.is_available));
+      if (opts.min_experience !== undefined && opts.min_experience > 0) params.append("min_experience", String(opts.min_experience));
+      if (opts.min_rate !== undefined && opts.min_rate > 0) params.append("min_rate", String(opts.min_rate));
+      if (opts.max_rate !== undefined && opts.max_rate > 0) params.append("max_rate", String(opts.max_rate));
+      if (opts.is_available !== undefined) params.append("available", String(opts.is_available));
       return request<PaginatedArtisansResponse>(`/artisans/nearby?${params}`);
     },
     getProfile: (artisanId: number) =>


### PR DESCRIPTION
IThis pr closes #232 


This PR implements advanced filters for the artisan discovery page, allowing users to filter by multi-select specialties, price range, and experience in addition to location and rating.

 Changes Made

Backend:
- Updated NearbyArtisansReques schema to include min_experience_years, min_rate, and `max_rate`.
- Modified the `get_nearby_artisans` endpoint to accept multiple `skills` as a list of strings along with the new filter parameters.
- Enhanced the `find_nearby_artisans` service logic to dynamically apply the new filters (`experience_years`, `hourly_rate`) to the database query.
- Updated Redis caching logic to include the new parameters in the cache key footprint for deterministic caching.

Frontend:
- Transformed the top filter bar into a sticky Desktop Filter Sidebar for a more scalable UI layout.
- Replaced the single-select specialty dropdown with a multi-select badge system allowing combinations of specialties.
- Added new filter components (range sliders and inputs) for Min Experience, Min Rate, and Max Rate to both desktop sidebar and mobile filter drawer.
- Updated the API client (`api.ts`) to stringify the multi-select `skills` array and gracefully append the new parameters to the request.
- Tied the new filters to the native debouncing mechanism, ensuring that dynamic result counts update automatically without user friction.

