### PR TITLE
Add PUT /artisans/location endpoint with Redis GEOADD + 15min TTL

### DIFF
--- a/backend/app/api/v1/endpoints/artisan.py
+++ b/backend/app/api/v1/endpoints/artisan.py
@@ -18,6 +18,7 @@ from app.models.portfolio import Portfolio
 from app.models.user import User
 from app.schemas.artisan import (
     ArtisanAvailabilityUpdate,
+    ArtisanLocationRealtimeUpdate,
     ArtisanLocationUpdate,
     ArtisanOut,
     ArtisanProfileCreate,
@@ -229,6 +230,38 @@ async def update_artisan_location(
             detail="Failed to update location",
         )
     return updated_artisan
+
+
+@router.put("/location/realtime")
+async def update_artisan_location_realtime(
+    location_data: ArtisanLocationRealtimeUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_artisan),
+):
+    """Push real-time artisan location to Redis (no PostgreSQL write).
+
+    Location data is stored in the Redis geo sorted-set (artisan_locations)
+    and the per-artisan hash (artisan_geo:{id}) with a 15-minute TTL.
+    The entry expires automatically after 15 minutes of inactivity;
+    find_nearby_artisans filters and cleans up stale members on reads.
+    """
+    service = ArtisanService(db)
+    artisan = service.get_artisan_by_user_id(current_user.id)
+    if not artisan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Artisan profile not found"
+        )
+
+    success = await geolocation_service.add_artisan_location(
+        artisan.id, location_data.latitude, location_data.longitude
+    )
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Location service unavailable",
+        )
+
+    return {"status": "ok"}
 
 
 @router.post("/geocode", response_model=GeolocationResponse)

--- a/backend/app/schemas/artisan.py
+++ b/backend/app/schemas/artisan.py
@@ -60,6 +60,18 @@ class ArtisanLocationUpdate(BaseModel):
         return v
 
 
+class ArtisanLocationRealtimeUpdate(BaseModel):
+    """Minimal schema for real-time, Redis-only artisan location updates.
+
+    Unlike ArtisanLocationUpdate, both coordinates are *required* and no
+    PostgreSQL write is performed — data is stored only in the Redis geo
+    index with a 15-minute TTL.
+    """
+
+    latitude: float = Field(..., ge=-90, le=90, description="Latitude coordinate")
+    longitude: float = Field(..., ge=-180, le=180, description="Longitude coordinate")
+
+
 class ArtisanProfileCreate(BaseModel):
     business_name: str | None = Field(None, max_length=200)
     description: str | None = None

--- a/backend/app/services/geolocation.py
+++ b/backend/app/services/geolocation.py
@@ -85,6 +85,11 @@ class GeolocationService:
             }
             await cache.redis.hset(f"artisan_geo:{artisan_id}", mapping=artisan_data)
 
+            # Set a 15-minute TTL on the hash; the geo sorted-set member
+            # (artisan_locations) does not support per-member expiry, so the
+            # hash's presence acts as the liveness signal.
+            await cache.redis.expire(f"artisan_geo:{artisan_id}", 900)
+
             return True
         except Exception as e:
             print(f"Error adding artisan location to Redis: {e}")
@@ -136,10 +141,21 @@ class GeolocationService:
             )
 
             nearby_artisans = []
+            expired_ids: list[str] = []
             for result in results:
                 artisan_id = int(result[0])
                 distance_m = float(result[1])
                 coordinates = result[2]
+
+                # Liveness check: the geo sorted-set member does not auto-expire,
+                # so we use the presence of the artisan_geo hash (which has a TTL)
+                # as the authoritative liveness signal.
+                hash_key = f"artisan_geo:{artisan_id}"
+                is_alive = await cache.redis.exists(hash_key)
+                if not is_alive:
+                    # Collect expired members to remove from the geo index.
+                    expired_ids.append(str(artisan_id))
+                    continue
 
                 nearby_artisans.append(
                     {
@@ -149,6 +165,10 @@ class GeolocationService:
                         "longitude": coordinates[0],
                     }
                 )
+
+            # Evict stale members from the geo sorted-set to keep the index lean.
+            if expired_ids:
+                await cache.redis.zrem(self.redis_key, *expired_ids)
 
             return nearby_artisans
 

--- a/backend/app/tests/test_realtime_location.py
+++ b/backend/app/tests/test_realtime_location.py
@@ -1,0 +1,132 @@
+"""Tests for the Redis-only real-time artisan location endpoint.
+
+PUT /api/v1/artisans/location/realtime
+- Secured with require_artisan (artisan role only).
+- Must NOT write to PostgreSQL.
+- Returns {"status": "ok"} on success.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure required env vars are set before importing app modules.
+os.environ.setdefault("SECRET_KEY", "test-secret-key-realtime")
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test_realtime.db")
+os.environ.setdefault("REQUIRE_EMAIL_VERIFICATION", "False")
+
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import settings as _settings
+from app.core.security import create_access_token, get_password_hash
+from app.db.base import Base
+from app.db.session import get_db
+from app.main import app
+from app.models.user import User
+
+_settings.REQUIRE_EMAIL_VERIFICATION = False
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test_realtime.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+REALTIME_LOCATION_URL = "/api/v1/artisans/location/realtime"
+VALID_PAYLOAD = {"latitude": 6.5244, "longitude": 3.3792}
+
+
+def override_get_db():
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    """Create schema once per test, drop after."""
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def test_client():
+    """TestClient with DB and Redis mocked out."""
+    app.dependency_overrides[get_db] = override_get_db
+    with (
+        patch("app.core.cache.cache.initialize", new_callable=AsyncMock),
+        patch("app.core.cache.cache.redis", new_callable=AsyncMock),
+        patch("app.core.security.redis_client"),
+    ):
+        with TestClient(app) as client:
+            yield client
+    app.dependency_overrides.clear()
+
+
+def _create_user(role: str) -> User:
+    """Insert a test user with the given role into the test DB."""
+    db = TestingSessionLocal()
+    try:
+        user = User(
+            email=f"{role}_realtime@test.com",
+            hashed_password=get_password_hash("TestPass123!"),
+            role=role,
+            full_name=f"Test {role.capitalize()}",
+            is_active=True,
+            is_verified=True,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return user
+    finally:
+        db.close()
+
+
+def _auth_headers(user_id: int) -> dict:
+    token = create_access_token(subject=user_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Core test: non-artisan (client role) must be rejected
+# ---------------------------------------------------------------------------
+
+
+def test_client_role_cannot_update_realtime_location(test_client: TestClient):
+    """A user with the 'client' role must receive 401 or 403 from the
+    Redis-only real-time location endpoint — it is artisan-only."""
+    client_user = _create_user("client")
+    headers = _auth_headers(client_user.id)
+
+    response = test_client.put(REALTIME_LOCATION_URL, json=VALID_PAYLOAD, headers=headers)
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401 or 403 for client role, got {response.status_code}: "
+        f"{response.json()}"
+    )
+
+
+def test_unauthenticated_request_is_rejected(test_client: TestClient):
+    """Requests without any token must be rejected (401/403)."""
+    response = test_client.put(REALTIME_LOCATION_URL, json=VALID_PAYLOAD)
+    assert response.status_code in (401, 403), (
+        f"Expected 401 or 403 for unauthenticated request, got {response.status_code}"
+    )
+
+
+def test_invalid_token_is_rejected(test_client: TestClient):
+    """A syntactically invalid JWT must be rejected with 401."""
+    headers = {"Authorization": "Bearer this.is.not.a.valid.token"}
+    response = test_client.put(REALTIME_LOCATION_URL, json=VALID_PAYLOAD, headers=headers)
+    assert response.status_code == 401, (
+        f"Expected 401 for invalid token, got {response.status_code}"
+    )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"


### PR DESCRIPTION
Adds a high-frequency location update endpoint for artisans, writing exclusively to Redis to avoid PostgreSQL load. Reuses the existing artisan_locations geospatial index. Adds a 15-minute TTL on each artisan's companion hash entry so inactive/offline artisans are filtered out of nearby-search results, since Redis geo sorted-sets don't support per-member expiry natively. Includes a test verifying non-artisan roles are rejected.