### PR TITLE
feat: Smart Contract Escrow: Split Funding Mechanics

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -36,9 +36,11 @@ pub struct Escrow {
     pub artisan: Address,
     pub arbitrator: Address,
     pub token: Address,
-    pub amount: i128,
+    pub material_amount: i128,
+    pub labor_amount: i128,
     pub status: Status,
     pub deadline: u64,
+    pub materials_released: bool,
 }
 
 #[contracttype]
@@ -87,7 +89,8 @@ pub struct EngagementInitializedEvent {
     pub artisan: Address,
     pub arbitrator: Address,
     pub token: Address,
-    pub amount: i128,
+    pub material_amount: i128,
+    pub labor_amount: i128,
 }
 
 #[contracttype]
@@ -100,6 +103,15 @@ pub struct FundsDepositedEvent {
 
 #[contracttype]
 pub struct FundsReleasedEvent {
+    pub id: u64,
+    pub client: Address,
+    pub artisan: Address,
+    pub amount: i128,
+    pub token: Address,
+}
+
+#[contracttype]
+pub struct MaterialsReleasedEvent {
     pub id: u64,
     pub client: Address,
     pub artisan: Address,
@@ -203,7 +215,8 @@ impl EscrowContract {
         artisan: Address,
         arbitrator: Address,
         token: Address,
-        amount: i128,
+        material_amount: i128,
+        labor_amount: i128,
         deadline: u64,
         multisig_signers: Vec<Address>,
         multisig_threshold: u32,
@@ -219,8 +232,13 @@ impl EscrowContract {
             panic!("Arbitrator must be a third party");
         }
 
-        if amount <= 0 {
-            panic!("Amount must be greater than zero");
+        if material_amount < 0 || labor_amount < 0 {
+            panic!("Amounts must be non-negative");
+        }
+
+        let total = material_amount + labor_amount;
+        if total <= 0 {
+            panic!("Total amount must be greater than zero");
         }
 
         // Multi-sig validation
@@ -257,9 +275,11 @@ impl EscrowContract {
             artisan: artisan.clone(),
             arbitrator: arbitrator.clone(),
             token: token.clone(),
-            amount,
+            material_amount,
+            labor_amount,
             status: Status::Pending,
             deadline,
+            materials_released: false,
         };
 
         // Store the escrow record
@@ -278,7 +298,8 @@ impl EscrowContract {
                 artisan,
                 arbitrator,
                 token,
-                amount,
+                material_amount,
+                labor_amount,
             },
         );
 
@@ -319,12 +340,9 @@ impl EscrowContract {
         }
 
         // Transfer tokens from client to escrow contract
+        let total = escrow.material_amount + escrow.labor_amount;
         let token_client = token::Client::new(&env, &token);
-        token_client.transfer(
-            &escrow.client,
-            &env.current_contract_address(),
-            &escrow.amount,
-        );
+        token_client.transfer(&escrow.client, &env.current_contract_address(), &total);
 
         // Update escrow status to Funded
         escrow.status = Status::Funded;
@@ -336,13 +354,76 @@ impl EscrowContract {
             .extend_ttl(&key, TTL_THRESHOLD, ESCROW_TTL);
 
         // Emit event
+        let total = escrow.material_amount + escrow.labor_amount;
         env.events().publish(
             (Symbol::new(&env, "deposit"), engagement_id),
             FundsDepositedEvent {
                 id: engagement_id,
                 client: escrow.client,
-                amount: escrow.amount,
+                amount: total,
                 token: escrow.token,
+            },
+        );
+    }
+
+    /// Release material funds to the artisan immediately.
+    /// Transfers only the material_amount to the artisan so they can purchase parts.
+    /// This can be called by either the client or the artisan, and only once per engagement.
+    /// After this call, the labor_amount remains locked in the contract until the job is done.
+    pub fn release_materials(env: Env, engagement_id: u64, token: Address, caller: Address) {
+        assert!(!Self::is_paused(&env), "contract is paused");
+        let key = DataKey::Escrow(engagement_id);
+        let mut escrow: Escrow = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Escrow not found");
+
+        // Verify token matches initialized token
+        if token != escrow.token {
+            panic!("Token does not match the initialized token for this engagement");
+        }
+
+        // Auth: either the client or the artisan may trigger material release
+        caller.require_auth();
+        if caller != escrow.client && caller != escrow.artisan {
+            panic!("Only client or artisan can release materials");
+        }
+
+        // State check: must be funded or in progress
+        if escrow.status != Status::Funded && escrow.status != Status::InProgress {
+            panic!("Escrow must be Funded or InProgress to release materials");
+        }
+
+        // Guard: prevent double-spending of material funds
+        if escrow.materials_released {
+            panic!("Materials have already been released for this engagement");
+        }
+
+        // Transfer material_amount to artisan
+        let token_client = token::Client::new(&env, &token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &escrow.artisan,
+            &escrow.material_amount,
+        );
+
+        // Mark materials as released
+        escrow.materials_released = true;
+        env.storage().persistent().set(&key, &escrow);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, TTL_THRESHOLD, ESCROW_TTL);
+
+        // Emit event
+        env.events().publish(
+            (Symbol::new(&env, "release_materials"), engagement_id),
+            MaterialsReleasedEvent {
+                id: engagement_id,
+                client: escrow.client.clone(),
+                artisan: escrow.artisan.clone(),
+                amount: escrow.material_amount,
+                token: escrow.token.clone(),
             },
         );
     }
@@ -404,12 +485,19 @@ impl EscrowContract {
             env.storage().persistent().remove(&approvals_key);
         }
 
-        // Logic: Transfer the stored escrow amount from the contract address to the artisan's address
+        // Logic: Transfer the appropriate amount from the contract to artisan.
+        // If materials were already released, only labor_amount remains.
+        // Otherwise, transfer the full remaining balance.
+        let transfer_amount = if escrow.materials_released {
+            escrow.labor_amount
+        } else {
+            escrow.material_amount + escrow.labor_amount
+        };
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(
             &env.current_contract_address(),
             &escrow.artisan,
-            &escrow.amount,
+            &transfer_amount,
         );
 
         // State: Update the escrow status to Released
@@ -426,7 +514,7 @@ impl EscrowContract {
                 id: engagement_id,
                 client: escrow.client,
                 artisan: escrow.artisan,
-                amount: escrow.amount,
+                amount: transfer_amount,
                 token: escrow.token,
             },
         );
@@ -548,12 +636,21 @@ impl EscrowContract {
             panic!("Token does not match the initialized token for this engagement");
         }
 
+        // Determine refund amount: if materials have been released, the client
+        // only gets the locked labor amount back (materials cost is already paid
+        // to the artisan). Otherwise, the full balance is returned.
+        let refund_amount = if escrow.materials_released {
+            escrow.labor_amount
+        } else {
+            escrow.material_amount + escrow.labor_amount
+        };
+
         // Transfer funds back to the client
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(
             &env.current_contract_address(),
             &escrow.client,
-            &escrow.amount,
+            &refund_amount,
         );
 
         // Update state to Refunded
@@ -570,7 +667,7 @@ impl EscrowContract {
                 id: engagement_id,
                 client: escrow.client.clone(),
                 artisan: escrow.artisan.clone(),
-                amount: escrow.amount,
+                amount: refund_amount,
                 token: escrow.token.clone(),
                 timestamp: current_time,
             },
@@ -760,7 +857,7 @@ impl EscrowContract {
                 id: engagement_id,
                 client: escrow.client.clone(),
                 artisan: escrow.artisan.clone(),
-                amount: escrow.amount,
+                amount: escrow.material_amount + escrow.labor_amount,
                 token: escrow.token.clone(),
                 initiator,
                 timestamp: current_time,
@@ -802,7 +899,8 @@ impl EscrowContract {
         }
 
         // Validation: distribution must equal total escrow amount
-        if client_amount + artisan_amount != escrow.amount {
+        let total = escrow.material_amount + escrow.labor_amount;
+        if client_amount + artisan_amount != total {
             panic!("Distribution amounts must equal the escrowed amount");
         }
 
@@ -938,6 +1036,7 @@ mod test_legacy {
             &arbitrator_address,
             &token_address,
             &amount,
+            &0,
             &deadline,
             &soroban_sdk::vec![&env],
             &0u32,
@@ -957,9 +1056,11 @@ mod test_legacy {
         assert_eq!(stored_escrow.client, client_address);
         assert_eq!(stored_escrow.artisan, artisan_address);
         assert_eq!(stored_escrow.token, token_address);
-        assert_eq!(stored_escrow.amount, amount);
+        assert_eq!(stored_escrow.material_amount, amount);
+        assert_eq!(stored_escrow.labor_amount, 0);
         assert_eq!(stored_escrow.status, Status::Pending);
         assert_eq!(stored_escrow.deadline, deadline);
+        assert!(!stored_escrow.materials_released);
 
         // Verify next ID was updated
         let next_id: u64 = env.as_contract(&contract_id, || {
@@ -991,6 +1092,7 @@ mod test_legacy {
             &arbitrator_address,
             &token_address,
             &amount,
+            &0,
             &deadline,
             &soroban_sdk::vec![&env],
             &0u32,
@@ -998,7 +1100,7 @@ mod test_legacy {
     }
 
     #[test]
-    #[should_panic(expected = "Amount must be greater than zero")]
+    #[should_panic(expected = "Total amount must be greater than zero")]
     fn test_initialize_zero_amount() {
         let env = Env::default();
         let contract_id = env.register_contract(None, EscrowContract);
@@ -1011,13 +1113,14 @@ mod test_legacy {
         let zero_amount: i128 = 0;
         let deadline = env.ledger().timestamp() + 86400;
 
-        // This should panic because amount is zero
+        // This should panic because total amount is zero
         client.initialize(
             &client_address,
             &artisan_address,
             &arbitrator_address,
             &token_address,
             &zero_amount,
+            &0,
             &deadline,
             &soroban_sdk::vec![&env],
             &0u32,
@@ -1025,7 +1128,7 @@ mod test_legacy {
     }
 
     #[test]
-    #[should_panic(expected = "Amount must be greater than zero")]
+    #[should_panic(expected = "Amounts must be non-negative")]
     fn test_initialize_negative_amount() {
         let env = Env::default();
         let contract_id = env.register_contract(None, EscrowContract);
@@ -1045,6 +1148,7 @@ mod test_legacy {
             &arbitrator_address,
             &token_address,
             &negative_amount,
+            &0,
             &deadline,
             &soroban_sdk::vec![&env],
             &0u32,
@@ -1091,9 +1195,11 @@ mod test_legacy {
             artisan: artisan_address,
             arbitrator: Address::generate(&env),
             token: token_address.clone(),
-            amount: escrow_amount,
+            material_amount: escrow_amount,
+            labor_amount: 0,
             status: Status::Pending,
             deadline,
+            materials_released: false,
         };
 
         // Store the escrow in contract storage
@@ -1125,8 +1231,10 @@ mod test_legacy {
 
         // Verify other fields remain unchanged
         assert_eq!(updated_escrow.client, client_address);
-        assert_eq!(updated_escrow.amount, escrow_amount);
+        assert_eq!(updated_escrow.material_amount, escrow_amount);
+        assert_eq!(updated_escrow.labor_amount, 0);
         assert_eq!(updated_escrow.deadline, deadline);
+        assert!(!updated_escrow.materials_released);
     }
 
     #[test]
@@ -1160,9 +1268,11 @@ mod test_legacy {
             artisan: artisan_address,
             arbitrator: Address::generate(&env),
             token: token_address.clone(),
-            amount: escrow_amount,
+            material_amount: escrow_amount,
+            labor_amount: 0,
             status: Status::Pending,
             deadline,
+            materials_released: false,
         };
 
         env.as_contract(&contract_id, || {
@@ -1212,9 +1322,11 @@ mod test_legacy {
             artisan: artisan_address,
             arbitrator: Address::generate(&env),
             token: token_address.clone(),
-            amount: escrow_amount,
+            material_amount: escrow_amount,
+            labor_amount: 0,
             status: Status::Funded, // Already funded
             deadline,
+            materials_released: false,
         };
 
         // Store the escrow
@@ -1268,9 +1380,11 @@ mod test_legacy {
             artisan: artisan_address,
             arbitrator: Address::generate(&env),
             token: token_address.clone(),
-            amount: 500,
+            material_amount: 500,
+            labor_amount: 0,
             status: Status::Pending,
             deadline: env.ledger().timestamp().saturating_sub(1),
+            materials_released: false,
         };
         env.as_contract(&contract_id, || {
             env.storage()
@@ -1312,9 +1426,11 @@ mod test_legacy {
             artisan: artisan_address.clone(),
             arbitrator: Address::generate(&env),
             token: token_address.clone(),
-            amount,
+            material_amount: amount,
+            labor_amount: 0,
             status: Status::Funded,
             deadline,
+            materials_released: false,
         };
         env.as_contract(&contract_id, || {
             env.storage()
@@ -1350,9 +1466,11 @@ mod test_legacy {
             artisan: artisan_address,
             arbitrator: Address::generate(&env),
             token: token_address.clone(),
-            amount,
+            material_amount: amount,
+            labor_amount: 0,
             status: Status::Funded,
             deadline,
+            materials_released: false,
         };
         env.as_contract(&contract_id, || {
             env.storage()
@@ -1396,9 +1514,11 @@ mod test_legacy {
             artisan: artisan_address,
             arbitrator: Address::generate(&env),
             token: token_address.clone(),
-            amount,
+            material_amount: amount,
+            labor_amount: 0,
             status: Status::Funded,
             deadline,
+            materials_released: false,
         };
         env.as_contract(&contract_id, || {
             env.storage()
@@ -1463,9 +1583,11 @@ mod test_legacy {
             artisan: artisan_address,
             arbitrator: Address::generate(&env),
             token: token_address.clone(),
-            amount,
+            material_amount: amount,
+            labor_amount: 0,
             status: Status::Funded,
             deadline,
+            materials_released: false,
         };
         env.as_contract(&contract_id, || {
             env.storage()
@@ -1515,9 +1637,11 @@ mod test_legacy {
             artisan: artisan_address,
             arbitrator: Address::generate(&env),
             token: token_address.clone(),
-            amount,
+            material_amount: amount,
+            labor_amount: 0,
             status: Status::Pending,
             deadline,
+            materials_released: false,
         };
         env.as_contract(&contract_id, || {
             env.storage()
@@ -1557,9 +1681,11 @@ mod test_legacy {
             artisan: artisan_address,
             arbitrator: Address::generate(&env),
             token: token_address.clone(),
-            amount,
+            material_amount: amount,
+            labor_amount: 0,
             status: Status::Funded,
             deadline,
+            materials_released: false,
         };
 
         env.as_contract(&contract_id, || {
@@ -1608,9 +1734,11 @@ mod test_legacy {
             artisan: artisan_address.clone(),
             arbitrator: Address::generate(&env),
             token: token_address.clone(),
-            amount,
+            material_amount: amount,
+            labor_amount: 0,
             status: Status::Funded,
             deadline,
+            materials_released: false,
         };
 
         // Store the escrow
@@ -1656,9 +1784,11 @@ mod test_legacy {
             artisan: artisan_address,
             arbitrator: Address::generate(&env),
             token: token_address.clone(),
-            amount,
+            material_amount: amount,
+            labor_amount: 0,
             status: Status::Pending,
             deadline,
+            materials_released: false,
         };
 
         env.as_contract(&contract_id, || {
@@ -1698,9 +1828,11 @@ mod test_legacy {
             artisan: artisan_address,
             arbitrator: Address::generate(&env),
             token: token_address.clone(),
-            amount,
+            material_amount: amount,
+            labor_amount: 0,
             status: Status::Funded,
             deadline,
+            materials_released: false,
         };
 
         env.as_contract(&contract_id, || {

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -56,12 +56,19 @@ mod happy_path_tests {
         }
 
         /// Initialize an engagement with the default arbitrator and token
-        fn initialize_engagement(&self, client: &Address, artisan: &Address, amount: i128) -> u64 {
+        fn initialize_engagement(
+            &self,
+            client: &Address,
+            artisan: &Address,
+            material_amount: i128,
+            labor_amount: i128,
+        ) -> u64 {
             self.initialize_engagement_with_arbitrator(
                 client,
                 artisan,
                 &self.default_arbitrator.clone(),
-                amount,
+                material_amount,
+                labor_amount,
             )
         }
 
@@ -71,7 +78,8 @@ mod happy_path_tests {
             client: &Address,
             artisan: &Address,
             arbitrator: &Address,
-            amount: i128,
+            material_amount: i128,
+            labor_amount: i128,
         ) -> u64 {
             let deadline = self.env.ledger().timestamp() + 86400;
             self.client_contract.initialize(
@@ -79,7 +87,8 @@ mod happy_path_tests {
                 artisan,
                 arbitrator,
                 &self.token_address,
-                &amount,
+                &material_amount,
+                &labor_amount,
                 &deadline,
                 &soroban_sdk::vec![&self.env],
                 &0u32,
@@ -104,16 +113,30 @@ mod happy_path_tests {
         }
 
         /// Full workflow: initialize, mint, deposit
-        fn full_deposit_workflow(&self, client: &Address, artisan: &Address, amount: i128) -> u64 {
-            let engagement_id = self.initialize_engagement(client, artisan, amount);
-            self.mint_tokens(client, amount);
+        fn full_deposit_workflow(
+            &self,
+            client: &Address,
+            artisan: &Address,
+            material_amount: i128,
+            labor_amount: i128,
+        ) -> u64 {
+            let engagement_id =
+                self.initialize_engagement(client, artisan, material_amount, labor_amount);
+            self.mint_tokens(client, material_amount + labor_amount);
             self.deposit_funds(engagement_id);
             engagement_id
         }
 
         /// Full workflow: initialize, mint, deposit, release
-        fn full_workflow(&self, client: &Address, artisan: &Address, amount: i128) -> u64 {
-            let engagement_id = self.full_deposit_workflow(client, artisan, amount);
+        fn full_workflow(
+            &self,
+            client: &Address,
+            artisan: &Address,
+            material_amount: i128,
+            labor_amount: i128,
+        ) -> u64 {
+            let engagement_id =
+                self.full_deposit_workflow(client, artisan, material_amount, labor_amount);
             self.release_funds(engagement_id);
             engagement_id
         }
@@ -131,15 +154,17 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
+        let labor_amount: i128 = 0;
 
-        let engagement_id = ctx.initialize_engagement(&client, &artisan, amount);
+        let engagement_id = ctx.initialize_engagement(&client, &artisan, amount, labor_amount);
 
         assert_eq!(engagement_id, 1, "First engagement should have ID 1");
 
         let escrow = ctx.get_escrow(engagement_id);
         assert_eq!(escrow.client, client);
         assert_eq!(escrow.artisan, artisan);
-        assert_eq!(escrow.amount, amount);
+        assert_eq!(escrow.material_amount, amount);
+        assert_eq!(escrow.labor_amount, labor_amount);
         assert_eq!(escrow.status, Status::Pending);
     }
 
@@ -173,8 +198,10 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let escrow_amount: i128 = 5000;
+        let labor_amount: i128 = 0;
 
-        let engagement_id = ctx.initialize_engagement(&client, &artisan, escrow_amount);
+        let engagement_id =
+            ctx.initialize_engagement(&client, &artisan, escrow_amount, labor_amount);
         ctx.mint_tokens(&client, 10000);
 
         let initial_client_balance = ctx.token_client.balance(&client);
@@ -195,7 +222,7 @@ mod happy_path_tests {
 
         let escrow = ctx.get_escrow(engagement_id);
         assert_eq!(escrow.status, Status::Funded);
-        assert_eq!(escrow.amount, escrow_amount);
+        assert_eq!(escrow.material_amount, escrow_amount);
     }
 
     /// Test 4: Release Funds to Artisan
@@ -205,8 +232,10 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let escrow_amount: i128 = 5000;
+        let labor_amount: i128 = 0;
 
-        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, escrow_amount);
+        let engagement_id =
+            ctx.full_deposit_workflow(&client, &artisan, escrow_amount, labor_amount);
 
         let artisan_balance_before = ctx.token_client.balance(&artisan);
         ctx.release_funds(engagement_id);
@@ -233,8 +262,9 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
+        let labor_amount: i128 = 0;
 
-        let engagement_id = ctx.full_workflow(&client, &artisan, amount);
+        let engagement_id = ctx.full_workflow(&client, &artisan, amount, labor_amount);
 
         // Verify final balances
         assert_eq!(
@@ -272,12 +302,12 @@ mod happy_path_tests {
         // First engagement
         let (client1, artisan1) = create_addresses(&ctx.env);
         let amount1 = 1000i128;
-        let id1 = ctx.full_deposit_workflow(&client1, &artisan1, amount1);
+        let id1 = ctx.full_deposit_workflow(&client1, &artisan1, amount1, 0);
 
         // Second engagement
         let (client2, artisan2) = create_addresses(&ctx.env);
         let amount2 = 2000i128;
-        let id2 = ctx.full_deposit_workflow(&client2, &artisan2, amount2);
+        let id2 = ctx.full_deposit_workflow(&client2, &artisan2, amount2, 0);
 
         // Verify both are funded
         assert_eq!(
@@ -302,7 +332,7 @@ mod happy_path_tests {
         let (client, artisan) = create_addresses(&ctx.env);
         let large_amount: i128 = 1_000_000_000_000;
 
-        ctx.full_workflow(&client, &artisan, large_amount);
+        ctx.full_workflow(&client, &artisan, large_amount, 0);
 
         assert_eq!(ctx.token_client.balance(&artisan), large_amount);
         assert_eq!(ctx.token_client.balance(&ctx.contract_id), 0);
@@ -315,8 +345,9 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
+        let labor_amount: i128 = 0;
 
-        let engagement_id = ctx.initialize_engagement(&client, &artisan, amount);
+        let engagement_id = ctx.initialize_engagement(&client, &artisan, amount, labor_amount);
         ctx.mint_tokens(&client, amount);
         ctx.deposit_funds(engagement_id);
 
@@ -337,7 +368,7 @@ mod happy_path_tests {
             let (client, artisan) = create_addresses(&ctx.env);
             let amount: i128 = 1000 * i as i128;
 
-            let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount);
+            let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount, 0);
 
             // After deposit, contract should hold the amount (no other engagements pending)
             assert_eq!(
@@ -361,9 +392,10 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
+        let labor_amount: i128 = 0;
 
         // Initialize and check state
-        let engagement_id = ctx.initialize_engagement(&client, &artisan, amount);
+        let engagement_id = ctx.initialize_engagement(&client, &artisan, amount, labor_amount);
         let escrow = ctx.get_escrow(engagement_id);
         assert_eq!(escrow.status, Status::Pending);
         assert_eq!(escrow.client, client);
@@ -375,7 +407,7 @@ mod happy_path_tests {
         let escrow = ctx.get_escrow(engagement_id);
         assert_eq!(escrow.status, Status::Funded);
         assert_eq!(escrow.client, client);
-        assert_eq!(escrow.amount, amount);
+        assert_eq!(escrow.material_amount, amount);
 
         // Release and check final state
         ctx.release_funds(engagement_id);
@@ -391,6 +423,7 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
+        let labor_amount: i128 = 0;
 
         // set a short deadline a few seconds in the future
         let now = ctx.env.ledger().timestamp();
@@ -401,6 +434,7 @@ mod happy_path_tests {
             &ctx.default_arbitrator,
             &ctx.token_address,
             &amount,
+            &labor_amount,
             &deadline,
             &soroban_sdk::vec![&ctx.env],
             &0u32,
@@ -445,7 +479,7 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
-        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount);
+        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount, 0);
         let original_deadline = ctx.get_escrow(engagement_id).deadline;
         let new_deadline = original_deadline + 3600;
 
@@ -463,7 +497,7 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
-        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount);
+        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount, 0);
         let original_deadline = ctx.get_escrow(engagement_id).deadline;
         let new_deadline = original_deadline + 7200;
 
@@ -483,7 +517,7 @@ mod happy_path_tests {
         let (client, artisan) = create_addresses(&ctx.env);
         let unauthorized = Address::generate(&ctx.env);
         let amount: i128 = 5000;
-        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount);
+        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount, 0);
         let new_deadline = ctx.get_escrow(engagement_id).deadline + 3600;
 
         ctx.client_contract
@@ -496,7 +530,7 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
-        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount);
+        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount, 0);
         let new_deadline = ctx.get_escrow(engagement_id).deadline + 3600;
 
         ctx.client_contract
@@ -511,7 +545,7 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
-        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount);
+        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount, 0);
         let original_deadline = ctx.get_escrow(engagement_id).deadline;
 
         ctx.client_contract
@@ -526,7 +560,7 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
-        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount);
+        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount, 0);
         let current_deadline = ctx.get_escrow(engagement_id).deadline;
 
         ctx.client_contract
@@ -541,7 +575,7 @@ mod happy_path_tests {
         let amount: i128 = 5000;
 
         // Setup: Initialize, mint, and deposit
-        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount);
+        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount, 0);
 
         // Verify initial state is Funded
         assert_eq!(ctx.get_escrow(engagement_id).status, Status::Funded);
@@ -562,7 +596,7 @@ mod happy_path_tests {
         let amount: i128 = 5000;
 
         // Setup: Initialize, mint, and deposit
-        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount);
+        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount, 0);
 
         // Verify initial state is Funded
         assert_eq!(ctx.get_escrow(engagement_id).status, Status::Funded);
@@ -584,7 +618,7 @@ mod happy_path_tests {
         let amount: i128 = 5000;
 
         // Setup: Initialize but don't deposit (escrow remains Pending)
-        let engagement_id = ctx.initialize_engagement(&client, &artisan, amount);
+        let engagement_id = ctx.initialize_engagement(&client, &artisan, amount, 0);
 
         // Attempt to dispute Pending escrow should fail
         ctx.client_contract.dispute(&engagement_id, &client);
@@ -599,7 +633,7 @@ mod happy_path_tests {
         let amount: i128 = 5000;
 
         // Setup: Initialize, mint, and deposit
-        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount);
+        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount, 0);
 
         // First dispute succeeds
         ctx.client_contract.dispute(&engagement_id, &client);
@@ -618,7 +652,7 @@ mod happy_path_tests {
         let amount: i128 = 5000;
 
         // Setup: Initialize, mint, and deposit
-        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount);
+        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount, 0);
 
         // Third party attempts to dispute
         let unauthorized = Address::generate(&ctx.env);
@@ -635,7 +669,7 @@ mod happy_path_tests {
 
         // Setup: Initialize with per-escrow arbitrator, mint, and deposit
         let engagement_id =
-            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount);
+            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount, 0);
         ctx.mint_tokens(&client, amount);
         ctx.deposit_funds(engagement_id);
 
@@ -669,7 +703,7 @@ mod happy_path_tests {
 
         // Setup: Initialize with per-escrow arbitrator, mint, and deposit
         let engagement_id =
-            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount);
+            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount, 0);
         ctx.mint_tokens(&client, amount);
         ctx.deposit_funds(engagement_id);
 
@@ -704,7 +738,7 @@ mod happy_path_tests {
 
         // Setup: Initialize with per-escrow arbitrator, mint, and deposit
         let engagement_id =
-            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount);
+            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount, 0);
         ctx.mint_tokens(&client, amount);
         ctx.deposit_funds(engagement_id);
 
@@ -730,7 +764,7 @@ mod happy_path_tests {
 
         // Setup: Initialize with per-escrow arbitrator, mint, and deposit
         let engagement_id =
-            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount);
+            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount, 0);
         ctx.mint_tokens(&client, amount);
         ctx.deposit_funds(engagement_id);
 
@@ -753,7 +787,7 @@ mod happy_path_tests {
 
         // Setup: Initialize with per-escrow arbitrator, mint, and deposit (but don't dispute)
         let engagement_id =
-            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount);
+            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount, 0);
         ctx.mint_tokens(&client, amount);
         ctx.deposit_funds(engagement_id);
 
@@ -772,7 +806,7 @@ mod happy_path_tests {
 
         // Setup: Initialize with per-escrow arbitrator, mint, and deposit
         let engagement_id =
-            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount);
+            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount, 0);
         ctx.mint_tokens(&client, amount);
         ctx.deposit_funds(engagement_id);
 
@@ -827,7 +861,7 @@ mod happy_path_tests {
 
         // Setup: Initialize with per-escrow arbitrator, mint, and deposit
         let engagement_id =
-            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount);
+            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount, 0);
         ctx.mint_tokens(&client, amount);
         ctx.deposit_funds(engagement_id);
 
@@ -849,7 +883,7 @@ mod happy_path_tests {
 
         // Setup: Initialize with per-escrow arbitrator, mint, and deposit
         let engagement_id =
-            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount);
+            ctx.initialize_engagement_with_arbitrator(&client, &artisan, &arbitrator, amount, 0);
         ctx.mint_tokens(&client, amount);
         ctx.deposit_funds(engagement_id);
 
@@ -888,6 +922,7 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
+        let labor_amount: i128 = 0;
 
         let now = ctx.env.ledger().timestamp();
         let deadline = now + 10;
@@ -897,6 +932,7 @@ mod happy_path_tests {
             &ctx.default_arbitrator,
             &ctx.token_address,
             &amount,
+            &labor_amount,
             &deadline,
             &soroban_sdk::vec![&ctx.env],
             &0u32,
@@ -919,6 +955,7 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
+        let labor_amount: i128 = 0;
 
         let now = ctx.env.ledger().timestamp();
         let deadline = now + 10;
@@ -928,6 +965,7 @@ mod happy_path_tests {
             &ctx.default_arbitrator,
             &ctx.token_address,
             &amount,
+            &labor_amount,
             &deadline,
             &soroban_sdk::vec![&ctx.env],
             &0u32,
@@ -955,6 +993,7 @@ mod happy_path_tests {
         let ctx = TestContext::new();
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
+        let labor_amount: i128 = 0;
 
         let now = ctx.env.ledger().timestamp();
         let deadline = now + 10;
@@ -964,6 +1003,7 @@ mod happy_path_tests {
             &ctx.default_arbitrator,
             &ctx.token_address,
             &amount,
+            &labor_amount,
             &deadline,
             &soroban_sdk::vec![&ctx.env],
             &0u32,
@@ -1001,7 +1041,7 @@ mod happy_path_tests {
         let unauthorized = Address::generate(&ctx.env);
         let amount: i128 = 5000;
 
-        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount);
+        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount, 0);
 
         // Third party attempts to approve early reclaim
         ctx.client_contract
@@ -1016,7 +1056,7 @@ mod happy_path_tests {
         let (client, artisan) = create_addresses(&ctx.env);
         let amount: i128 = 5000;
 
-        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount);
+        let engagement_id = ctx.full_deposit_workflow(&client, &artisan, amount, 0);
 
         // Client approves twice
         ctx.client_contract
@@ -1091,7 +1131,11 @@ mod ttl_snapshot_tests {
             });
         }
 
-        fn initialize_and_fund(&self, amount: i128) -> (u64, Address, Address) {
+        fn initialize_and_fund(
+            &self,
+            material_amount: i128,
+            labor_amount: i128,
+        ) -> (u64, Address, Address) {
             let client_addr = Address::generate(&self.env);
             let artisan_addr = Address::generate(&self.env);
             let arbitrator = Address::generate(&self.env);
@@ -1101,12 +1145,14 @@ mod ttl_snapshot_tests {
                 &artisan_addr,
                 &arbitrator,
                 &self.token_address,
-                &amount,
+                &material_amount,
+                &labor_amount,
                 &deadline,
                 &soroban_sdk::vec![&self.env],
                 &0u32,
             );
-            self.token_asset_client.mint(&client_addr, &amount);
+            self.token_asset_client
+                .mint(&client_addr, &(material_amount + labor_amount));
             self.client.deposit(&id, &self.token_address);
             (id, client_addr, artisan_addr)
         }
@@ -1116,7 +1162,7 @@ mod ttl_snapshot_tests {
     #[test]
     fn test_ttl_record_persists_after_30_days() {
         let ctx = TtlCtx::new();
-        let (id, _, _) = ctx.initialize_and_fund(1_000);
+        let (id, _, _) = ctx.initialize_and_fund(1_000, 0);
 
         // Advance ~30 days (30 * DAY_LEDGERS)
         ctx.jump_ledgers(30 * DAY_LEDGERS);
@@ -1146,6 +1192,7 @@ mod ttl_snapshot_tests {
             &arbitrator,
             &ctx.token_address,
             &1_000i128,
+            &0i128,
             &deadline,
             &soroban_sdk::vec![&ctx.env],
             &0u32,
@@ -1174,7 +1221,7 @@ mod ttl_snapshot_tests {
     #[test]
     fn test_ttl_extends_on_release() {
         let ctx = TtlCtx::new();
-        let (id, _, artisan_addr) = ctx.initialize_and_fund(2_000);
+        let (id, _, artisan_addr) = ctx.initialize_and_fund(2_000, 0);
 
         // Advance 10 days, then release
         ctx.jump_ledgers(10 * DAY_LEDGERS);
@@ -1208,6 +1255,7 @@ mod ttl_snapshot_tests {
             &arbitrator,
             &ctx.token_address,
             &500i128,
+            &0i128,
             &deadline,
             &soroban_sdk::vec![&ctx.env],
             &0u32,
@@ -1236,7 +1284,7 @@ mod ttl_snapshot_tests {
     #[test]
     fn test_ttl_extends_on_dispute() {
         let ctx = TtlCtx::new();
-        let (id, client_addr, _) = ctx.initialize_and_fund(3_000);
+        let (id, client_addr, _) = ctx.initialize_and_fund(3_000, 0);
 
         ctx.jump_ledgers(5 * DAY_LEDGERS);
         ctx.client.dispute(&id, &client_addr);
@@ -1310,6 +1358,7 @@ mod multisig_tests {
             &arbitrator,
             &ctx.token_address,
             &amount,
+            &0i128,
             &deadline,
             &vec![&ctx.env], // empty → no multisig
             &0u32,
@@ -1348,6 +1397,7 @@ mod multisig_tests {
             &arbitrator,
             &ctx.token_address,
             &amount,
+            &0i128,
             &deadline,
             &signers,
             &2u32, // 2-of-2
@@ -1393,6 +1443,7 @@ mod multisig_tests {
             &arbitrator,
             &ctx.token_address,
             &amount,
+            &0i128,
             &deadline,
             &signers,
             &2u32,
@@ -1426,6 +1477,7 @@ mod multisig_tests {
             &arbitrator,
             &ctx.token_address,
             &amount,
+            &0i128,
             &deadline,
             &signers,
             &1u32, // 1-of-2
@@ -1460,6 +1512,7 @@ mod multisig_tests {
             &arbitrator,
             &ctx.token_address,
             &amount,
+            &0i128,
             &deadline,
             &signers,
             &1u32,
@@ -1490,6 +1543,7 @@ mod multisig_tests {
             &arbitrator,
             &ctx.token_address,
             &amount,
+            &0i128,
             &deadline,
             &signers,
             &1u32,
@@ -1519,6 +1573,7 @@ mod multisig_tests {
             &arbitrator,
             &ctx.token_address,
             &1_000i128,
+            &0i128,
             &deadline,
             &signers,
             &0u32, // invalid
@@ -1543,6 +1598,7 @@ mod multisig_tests {
             &arbitrator,
             &ctx.token_address,
             &1_000i128,
+            &0i128,
             &deadline,
             &signers,
             &3u32, // threshold > signers count
@@ -1602,6 +1658,7 @@ mod cleanup_tests {
                 &arbitrator,
                 &self.token_address,
                 &amount,
+                &0i128,
                 &deadline,
                 &vec![&self.env],
                 &0u32,
@@ -1624,6 +1681,7 @@ mod cleanup_tests {
                 &arbitrator,
                 &self.token_address,
                 &amount,
+                &0i128,
                 &deadline,
                 &vec![&self.env],
                 &0u32,
@@ -1719,6 +1777,7 @@ mod cleanup_tests {
             &arbitrator,
             &ctx.token_address,
             &amount,
+            &0i128,
             &deadline,
             &vec![&ctx.env],
             &0u32,
@@ -1746,5 +1805,356 @@ mod cleanup_tests {
         assert!(!ctx.env.as_contract(&ctx.contract_id, || {
             ctx.env.storage().persistent().has(&DataKey::Escrow(id2))
         }));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #297 – Material/Labor Split tests
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod material_split_tests {
+    use crate::{DataKey, EscrowContract, EscrowContractClient, Status};
+    use soroban_sdk::testutils::{Address as AddressTestUtils, Ledger};
+    use soroban_sdk::{token, vec, Address, Env};
+
+    struct MatCtx {
+        env: Env,
+        contract_id: Address,
+        token_address: Address,
+        client: EscrowContractClient<'static>,
+        token_client: token::Client<'static>,
+        token_asset_client: token::StellarAssetClient<'static>,
+    }
+
+    impl MatCtx {
+        fn new() -> Self {
+            let env = Env::default();
+            env.mock_all_auths_allowing_non_root_auth();
+            let contract_id = env.register_contract(None, EscrowContract);
+            let token_admin = Address::generate(&env);
+            let tc = env.register_stellar_asset_contract_v2(token_admin);
+            let token_address = tc.address();
+            let client = EscrowContractClient::new(&env, &contract_id);
+            let token_client = token::Client::new(&env, &token_address);
+            let token_asset_client = token::StellarAssetClient::new(&env, &token_address);
+            MatCtx {
+                env,
+                contract_id,
+                token_address,
+                client,
+                token_client,
+                token_asset_client,
+            }
+        }
+
+        fn get_escrow(&self, id: u64) -> crate::Escrow {
+            self.env.as_contract(&self.contract_id, || {
+                self.env
+                    .storage()
+                    .persistent()
+                    .get(&DataKey::Escrow(id))
+                    .expect("escrow exists")
+            })
+        }
+    }
+
+    /// MS-1: release_materials transfers only the material_amount to artisan
+    /// and marks materials_released = true.
+    #[test]
+    fn test_release_materials_transfers_correct_amount() {
+        let ctx = MatCtx::new();
+        let client = Address::generate(&ctx.env);
+        let artisan = Address::generate(&ctx.env);
+        let mat = 1_000i128;
+        let lab = 2_000i128;
+
+        let id = ctx.client.initialize(
+            &client,
+            &artisan,
+            &Address::generate(&ctx.env),
+            &ctx.token_address,
+            &mat,
+            &lab,
+            &(ctx.env.ledger().timestamp() + 86400),
+            &vec![&ctx.env],
+            &0u32,
+        );
+        ctx.token_asset_client.mint(&client, &(mat + lab));
+        ctx.client.deposit(&id, &ctx.token_address);
+
+        let artisan_balance_before = ctx.token_client.balance(&artisan);
+        ctx.client
+            .release_materials(&id, &ctx.token_address, &client);
+        let artisan_balance_after = ctx.token_client.balance(&artisan);
+
+        // Artisan receives exactly the material amount
+        assert_eq!(artisan_balance_after, artisan_balance_before + mat);
+
+        // Contract still holds the labor amount
+        assert_eq!(ctx.token_client.balance(&ctx.contract_id), lab);
+
+        // State is updated
+        let escrow = ctx.get_escrow(id);
+        assert!(escrow.materials_released);
+        assert_eq!(escrow.material_amount, mat);
+        assert_eq!(escrow.labor_amount, lab);
+        assert_eq!(escrow.status, Status::Funded);
+    }
+
+    /// MS-2: release_materials blocks double-spending (second call panics).
+    #[test]
+    #[should_panic(expected = "Materials have already been released for this engagement")]
+    fn test_release_materials_double_spending_blocked() {
+        let ctx = MatCtx::new();
+        let client = Address::generate(&ctx.env);
+        let artisan = Address::generate(&ctx.env);
+        let mat = 1_000i128;
+        let lab = 2_000i128;
+
+        let id = ctx.client.initialize(
+            &client,
+            &artisan,
+            &Address::generate(&ctx.env),
+            &ctx.token_address,
+            &mat,
+            &lab,
+            &(ctx.env.ledger().timestamp() + 86400),
+            &vec![&ctx.env],
+            &0u32,
+        );
+        ctx.token_asset_client.mint(&client, &(mat + lab));
+        ctx.client.deposit(&id, &ctx.token_address);
+
+        // First call succeeds
+        ctx.client
+            .release_materials(&id, &ctx.token_address, &client);
+        // Second call must panic
+        ctx.client
+            .release_materials(&id, &ctx.token_address, &client);
+    }
+
+    /// MS-3: release_materials can also be called by the artisan.
+    #[test]
+    fn test_release_materials_by_artisan() {
+        let ctx = MatCtx::new();
+        let client = Address::generate(&ctx.env);
+        let artisan = Address::generate(&ctx.env);
+        let mat = 1_000i128;
+        let lab = 2_000i128;
+
+        let id = ctx.client.initialize(
+            &client,
+            &artisan,
+            &Address::generate(&ctx.env),
+            &ctx.token_address,
+            &mat,
+            &lab,
+            &(ctx.env.ledger().timestamp() + 86400),
+            &vec![&ctx.env],
+            &0u32,
+        );
+        ctx.token_asset_client.mint(&client, &(mat + lab));
+        ctx.client.deposit(&id, &ctx.token_address);
+
+        let artisan_balance_before = ctx.token_client.balance(&artisan);
+        // Artisan calls release_materials themselves
+        ctx.client
+            .release_materials(&id, &ctx.token_address, &artisan);
+        assert_eq!(
+            ctx.token_client.balance(&artisan),
+            artisan_balance_before + mat
+        );
+        assert_eq!(ctx.token_client.balance(&ctx.contract_id), lab);
+    }
+
+    /// MS-4: Unauthorized third party cannot call release_materials.
+    #[test]
+    #[should_panic(expected = "Only client or artisan can release materials")]
+    fn test_release_materials_unauthorized_fails() {
+        let ctx = MatCtx::new();
+        let client = Address::generate(&ctx.env);
+        let artisan = Address::generate(&ctx.env);
+        let unauthorized = Address::generate(&ctx.env);
+        let mat = 1_000i128;
+        let lab = 2_000i128;
+
+        let id = ctx.client.initialize(
+            &client,
+            &artisan,
+            &Address::generate(&ctx.env),
+            &ctx.token_address,
+            &mat,
+            &lab,
+            &(ctx.env.ledger().timestamp() + 86400),
+            &vec![&ctx.env],
+            &0u32,
+        );
+        ctx.token_asset_client.mint(&client, &(mat + lab));
+        ctx.client.deposit(&id, &ctx.token_address);
+
+        // Third party tries to release materials
+        ctx.client
+            .release_materials(&id, &ctx.token_address, &unauthorized);
+    }
+
+    /// MS-5: release after materials_released transfers only labor_amount.
+    #[test]
+    fn test_release_after_materials_released_transfers_labor_only() {
+        let ctx = MatCtx::new();
+        let client = Address::generate(&ctx.env);
+        let artisan = Address::generate(&ctx.env);
+        let mat = 1_000i128;
+        let lab = 2_000i128;
+
+        let id = ctx.client.initialize(
+            &client,
+            &artisan,
+            &Address::generate(&ctx.env),
+            &ctx.token_address,
+            &mat,
+            &lab,
+            &(ctx.env.ledger().timestamp() + 86400),
+            &vec![&ctx.env],
+            &0u32,
+        );
+        ctx.token_asset_client.mint(&client, &(mat + lab));
+        ctx.client.deposit(&id, &ctx.token_address);
+
+        // Release materials first
+        ctx.client
+            .release_materials(&id, &ctx.token_address, &client);
+        assert_eq!(ctx.token_client.balance(&ctx.contract_id), lab);
+
+        // Now release labor
+        let artisan_before = ctx.token_client.balance(&artisan);
+        ctx.client.release(&id, &ctx.token_address);
+        assert_eq!(ctx.token_client.balance(&artisan), artisan_before + lab);
+        assert_eq!(ctx.token_client.balance(&ctx.contract_id), 0);
+
+        let escrow = ctx.get_escrow(id);
+        assert_eq!(escrow.status, Status::Released);
+    }
+
+    /// MS-6: reclaim after materials_released refunds only labor_amount to client.
+    #[test]
+    fn test_reclaim_after_materials_released_refunds_labor_only() {
+        let ctx = MatCtx::new();
+        let client = Address::generate(&ctx.env);
+        let artisan = Address::generate(&ctx.env);
+        let mat = 1_000i128;
+        let lab = 2_000i128;
+
+        let deadline = ctx.env.ledger().timestamp() + 10;
+        let id = ctx.client.initialize(
+            &client,
+            &artisan,
+            &Address::generate(&ctx.env),
+            &ctx.token_address,
+            &mat,
+            &lab,
+            &deadline,
+            &vec![&ctx.env],
+            &0u32,
+        );
+        ctx.token_asset_client.mint(&client, &(mat + lab));
+        ctx.client.deposit(&id, &ctx.token_address);
+
+        // Release materials – material funds go to artisan
+        ctx.client
+            .release_materials(&id, &ctx.token_address, &client);
+        assert_eq!(ctx.token_client.balance(&artisan), mat);
+        assert_eq!(ctx.token_client.balance(&ctx.contract_id), lab);
+
+        // Fast-forward past deadline + grace period
+        ctx.env.ledger().set_timestamp(deadline + 86400 + 1);
+
+        // Client reclaims – only gets labor back (material is already with artisan)
+        let client_before = ctx.token_client.balance(&client);
+        ctx.client.reclaim(&id, &ctx.token_address);
+        let client_after = ctx.token_client.balance(&client);
+        assert_eq!(client_after, client_before + lab);
+
+        // Artisan keeps the material amount they received
+        assert_eq!(ctx.token_client.balance(&artisan), mat);
+
+        // Contract is empty
+        assert_eq!(ctx.token_client.balance(&ctx.contract_id), 0);
+
+        let escrow = ctx.get_escrow(id);
+        assert_eq!(escrow.status, Status::Refunded);
+    }
+
+    /// MS-7: reclaim without materials_released refunds the full amount.
+    #[test]
+    fn test_reclaim_without_materials_released_refunds_full() {
+        let ctx = MatCtx::new();
+        let client = Address::generate(&ctx.env);
+        let artisan = Address::generate(&ctx.env);
+        let mat = 1_000i128;
+        let lab = 2_000i128;
+        let total = mat + lab;
+
+        let deadline = ctx.env.ledger().timestamp() + 10;
+        let id = ctx.client.initialize(
+            &client,
+            &artisan,
+            &Address::generate(&ctx.env),
+            &ctx.token_address,
+            &mat,
+            &lab,
+            &deadline,
+            &vec![&ctx.env],
+            &0u32,
+        );
+        ctx.token_asset_client.mint(&client, &total);
+        ctx.client.deposit(&id, &ctx.token_address);
+
+        // Fast-forward past deadline + grace period (no release_materials called)
+        ctx.env.ledger().set_timestamp(deadline + 86400 + 1);
+
+        let client_before = ctx.token_client.balance(&client);
+        ctx.client.reclaim(&id, &ctx.token_address);
+        assert_eq!(
+            ctx.token_client.balance(&client),
+            client_before + total,
+            "Client should get full refund when materials not released"
+        );
+        assert_eq!(ctx.token_client.balance(&ctx.contract_id), 0);
+
+        let escrow = ctx.get_escrow(id);
+        assert_eq!(escrow.status, Status::Refunded);
+    }
+
+    /// MS-8: release without calling release_materials transfers everything.
+    #[test]
+    fn test_release_without_materials_released_transfers_full() {
+        let ctx = MatCtx::new();
+        let client = Address::generate(&ctx.env);
+        let artisan = Address::generate(&ctx.env);
+        let mat = 1_000i128;
+        let lab = 2_000i128;
+        let total = mat + lab;
+
+        let id = ctx.client.initialize(
+            &client,
+            &artisan,
+            &Address::generate(&ctx.env),
+            &ctx.token_address,
+            &mat,
+            &lab,
+            &(ctx.env.ledger().timestamp() + 86400),
+            &vec![&ctx.env],
+            &0u32,
+        );
+        ctx.token_asset_client.mint(&client, &total);
+        ctx.client.deposit(&id, &ctx.token_address);
+
+        let artisan_before = ctx.token_client.balance(&artisan);
+        ctx.client.release(&id, &ctx.token_address);
+        assert_eq!(ctx.token_client.balance(&artisan), artisan_before + total);
+
+        let escrow = ctx.get_escrow(id);
+        assert_eq!(escrow.status, Status::Released);
+        assert!(!escrow.materials_released);
     }
 }

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -48,9 +48,11 @@ pub struct EscrowEngagement {
     pub artisan: Address,
     pub arbitrator: Address,
     pub token: Address,
-    pub amount: i128,
+    pub material_amount: i128,
+    pub labor_amount: i128,
     pub status: EscrowStatus,
     pub deadline: u64,
+    pub materials_released: bool,
 }
 
 #[contractclient(name = "EscrowVerifierClient")]
@@ -233,9 +235,11 @@ mod tests {
             artisan: artisan.clone(),
             arbitrator: Address::generate(env),
             token: Address::generate(env),
-            amount: 1_000,
+            material_amount: 1_000,
+            labor_amount: 0,
             status,
             deadline: env.ledger().timestamp() + 1_000,
+            materials_released: false,
         };
 
         env.as_contract(escrow_contract_id, || {

--- a/contracts/reputation/src/test.rs
+++ b/contracts/reputation/src/test.rs
@@ -15,9 +15,11 @@ fn seed_escrow(
         artisan: artisan.clone(),
         arbitrator: Address::generate(env),
         token: Address::generate(env),
-        amount: 1_000,
+        material_amount: 1_000,
+        labor_amount: 0,
         status,
         deadline: env.ledger().timestamp() + 1_000,
+        materials_released: false,
     };
 
     env.as_contract(escrow_contract_id, || {


### PR DESCRIPTION
Closes #297 

## Implementations Made

Core Contract (contracts/escrow/src/lib.rs)

1. Escrow struct — replaced amount: i128 with material_amount: i128, labor_amount: i128, added materials_released: bool

2. Event structs — EngagementInitializedEvent now carries material_amount/labor_amount instead of amount. Added MaterialsReleasedEvent.

3. initialize() — accepts material_amount: i128, labor_amount: i128 instead of single amount. Validates both are non-negative and total > 0.

4. deposit() — transfers material_amount + labor_amount (single combined transaction) from client to contract.

5. release_materials() (new) — transfers only material_amount to artisan. Gated by materials_released bool to prevent double-spending. Callable by client or artisan.

6. release() — if materials_released, transfers only labor_amount. Otherwise transfers full balance.

7. reclaim() — if materials_released, refunds only labor_amount to client. Otherwise refunds full balance.

8. resolve_dispute() — validates against material_amount + labor_amount total.

### Test Files

contracts/escrow/src/test.rs — All 70 existing tests updated for new struct fields. 8 new material_split_tests added proving:

release_materials transfers correct amount
Double-spending is blocked
Artisan can also call release_materials
Unauthorized callers rejected
Release after materials_released transfers labor only
Reclaim after materials_released refunds labor only
Reclaim without materials_released refunds full amount
Release without release_materials transfers everything
contracts/escrow/src/lib.rs (test_legacy) — 17 tests updated.

contracts/reputation/src/lib.rs — EscrowEngagement mirror struct updated. Test module updated.

contracts/reputation/src/test.rs — Escrow construction updated.

Verification

78 escrow tests pass (70 original + 8 new)
19 reputation tests pass

<img width="734" height="475" alt="Screenshot 2026-06-19 at 14 13 10" src="https://github.com/user-attachments/assets/6e71d35a-dde3-425c-ab73-8ff9062d029d" />
<img width="782" height="180" alt="Screenshot 2026-06-19 at 14 13 36" src="https://github.com/user-attachments/assets/cd1f99f8-4492-42c5-92ac-54fb1214a8d6" />

