### PR TITLE
feat(backend): add artisan work history CSV export endpoint

### DIFF
--- a/backend/app/api/v1/endpoints/artisan.py
+++ b/backend/app/api/v1/endpoints/artisan.py
@@ -180,7 +180,11 @@ def export_my_work_history(
 
     filename = f"artisan-work-history-{artisan.id}.csv"
     headers = {"Content-Disposition": f'attachment; filename="{filename}"'}
-    return StreamingResponse(iter([output.getvalue()]), media_type="text/csv", headers=headers)
+    return StreamingResponse(
+        iter([output.getvalue()]),
+        media_type="text/csv",
+        headers=headers,
+    )
 
 
 # Other artisan-related endpoints from main

--- a/backend/app/api/v1/endpoints/artisan.py
+++ b/backend/app/api/v1/endpoints/artisan.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import csv
+import io
 import json
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session, joinedload
 
 from app.core.auth import (
@@ -145,6 +148,39 @@ def get_my_artisan_profile(
             status_code=status.HTTP_404_NOT_FOUND, detail="Artisan profile not found"
         )
     return artisan
+
+
+@router.get("/me/export")
+def export_my_work_history(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_artisan),
+):
+    """Export completed jobs and earnings for the authenticated artisan."""
+    service = ArtisanService(db)
+    artisan = service.get_artisan_by_user_id(current_user.id)
+    if not artisan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Artisan profile not found"
+        )
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["Date", "Job Title", "Client ID", "Amount Earned", "Rating"])
+
+    for row in service.get_completed_jobs_export_rows(artisan.id):
+        writer.writerow(
+            [
+                row["Date"],
+                row["Job Title"],
+                row["Client ID"],
+                row["Amount Earned"],
+                row["Rating"],
+            ]
+        )
+
+    filename = f"artisan-work-history-{artisan.id}.csv"
+    headers = {"Content-Disposition": f'attachment; filename="{filename}"'}
+    return StreamingResponse(iter([output.getvalue()]), media_type="text/csv", headers=headers)
 
 
 # Other artisan-related endpoints from main

--- a/backend/app/services/artisan.py
+++ b/backend/app/services/artisan.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from datetime import UTC, datetime
 
 from sqlalchemy import and_, or_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from app.core.cache import cache
 from app.models.artisan import Artisan
+from app.models.booking import Booking, BookingStatus
+from app.models.payment import PaymentStatus
 from app.schemas.artisan import (
     ArtisanProfileCreate,
     ArtisanProfileUpdate,
@@ -155,6 +158,58 @@ class ArtisanService:
     def get_artisan_by_user_id(self, user_id: int) -> Artisan | None:
         """Get artisan by user ID"""
         return self.db.query(Artisan).filter(Artisan.user_id == user_id).first()
+
+    def get_completed_jobs_export_rows(self, artisan_id: int) -> list[dict[str, str]]:
+        """Return completed jobs and earnings formatted for CSV export."""
+        bookings = (
+            self.db.query(Booking)
+            .options(selectinload(Booking.payments), selectinload(Booking.review))
+            .filter(
+                Booking.artisan_id == artisan_id,
+                Booking.status == BookingStatus.COMPLETED,
+            )
+            .order_by(Booking.date.desc(), Booking.created_at.desc())
+            .all()
+        )
+
+        rows: list[dict[str, str]] = []
+        for booking in bookings:
+            amount_earned = sum(
+                Decimal(payment.amount)
+                for payment in booking.payments
+                if payment.status
+                not in {
+                    PaymentStatus.FAILED,
+                    PaymentStatus.REFUNDED,
+                    PaymentStatus.DISPUTED,
+                }
+            )
+
+            if amount_earned == 0:
+                amount_earned = Decimal(
+                    booking.estimated_cost or booking.labor_cost or booking.material_cost or 0
+                )
+
+            rating = ""
+            if booking.review:
+                rating = str(booking.review[0].rating)
+
+            booking_date = booking.date or booking.created_at
+            rows.append(
+                {
+                    "Date": (
+                        booking_date.date().isoformat()
+                        if booking_date is not None
+                        else ""
+                    ),
+                    "Job Title": booking.service,
+                    "Client ID": str(booking.client_id),
+                    "Amount Earned": f"{amount_earned:.2f}",
+                    "Rating": rating,
+                }
+            )
+
+        return rows
 
     def list_artisans(
         self,

--- a/backend/app/services/artisan.py
+++ b/backend/app/services/artisan.py
@@ -177,7 +177,8 @@ class ArtisanService:
             amount_earned = sum(
                 Decimal(payment.amount)
                 for payment in booking.payments
-                if payment.status not in {
+                if payment.status
+                not in {
                     PaymentStatus.FAILED,
                     PaymentStatus.REFUNDED,
                     PaymentStatus.DISPUTED,

--- a/backend/app/services/artisan.py
+++ b/backend/app/services/artisan.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from decimal import Decimal
-import json
 
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session, selectinload

--- a/backend/app/services/artisan.py
+++ b/backend/app/services/artisan.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import json
-from decimal import Decimal
 from datetime import UTC, datetime
+from decimal import Decimal
+import json
 
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session, selectinload

--- a/backend/app/services/artisan.py
+++ b/backend/app/services/artisan.py
@@ -177,8 +177,7 @@ class ArtisanService:
             amount_earned = sum(
                 Decimal(payment.amount)
                 for payment in booking.payments
-                if payment.status
-                not in {
+                if payment.status not in {
                     PaymentStatus.FAILED,
                     PaymentStatus.REFUNDED,
                     PaymentStatus.DISPUTED,
@@ -187,7 +186,10 @@ class ArtisanService:
 
             if amount_earned == 0:
                 amount_earned = Decimal(
-                    booking.estimated_cost or booking.labor_cost or booking.material_cost or 0
+                    booking.estimated_cost
+                    or booking.labor_cost
+                    or booking.material_cost
+                    or 0
                 )
 
             rating = ""

--- a/backend/app/tests/test_crud_endpoints.py
+++ b/backend/app/tests/test_crud_endpoints.py
@@ -182,7 +182,9 @@ def test_artisan_can_export_completed_jobs_as_csv(client):
     )
     assert profile_resp.status_code == 200
 
-    client_headers = get_auth_headers(client, "export-cli@test.com", "Pass123!", "client")
+    client_headers = get_auth_headers(
+        client, "export-cli@test.com", "Pass123!", "client"
+    )
 
     completed_booking_resp = client.post(
         "api/v1/bookings/create",
@@ -217,7 +219,9 @@ def test_artisan_can_export_completed_jobs_as_csv(client):
 
     db = TestingSessionLocal()
     try:
-        artisan = db.query(Artisan).filter(Artisan.id == profile_resp.json()["id"]).first()
+        artisan = (
+            db.query(Artisan).filter(Artisan.id == profile_resp.json()["id"]).first()
+        )
         completed_booking = (
             db.query(Booking).filter(Booking.id == completed_booking_id).first()
         )

--- a/backend/app/tests/test_crud_endpoints.py
+++ b/backend/app/tests/test_crud_endpoints.py
@@ -2,6 +2,7 @@ import csv
 import io
 from datetime import datetime
 from decimal import Decimal
+from uuid import UUID
 
 from .conftest import TestingSessionLocal
 
@@ -200,7 +201,7 @@ def test_artisan_can_export_completed_jobs_as_csv(client):
         headers=client_headers,
     )
     assert completed_booking_resp.status_code == 201
-    completed_booking_id = completed_booking_resp.json()["id"]
+    completed_booking_id = UUID(completed_booking_resp.json()["id"])
 
     pending_booking_resp = client.post(
         "api/v1/bookings/create",

--- a/backend/app/tests/test_crud_endpoints.py
+++ b/backend/app/tests/test_crud_endpoints.py
@@ -1,4 +1,9 @@
+import csv
+import io
 from datetime import datetime
+from decimal import Decimal
+
+from .conftest import TestingSessionLocal
 
 
 def get_auth_headers(client, email, password, role):
@@ -155,3 +160,105 @@ def test_artisan_availability_rejects_non_artisan(client):
         headers=headers,
     )
     assert resp.status_code == 403
+
+
+def test_artisan_can_export_completed_jobs_as_csv(client):
+    from app.models.artisan import Artisan
+    from app.models.booking import Booking, BookingStatus
+    from app.models.payment import Payment, PaymentStatus
+    from app.models.review import Review
+
+    artisan_headers = get_auth_headers(
+        client, "export-art@test.com", "Pass123!", "artisan"
+    )
+    artisan_profile = {
+        "business_name": "Export Biz",
+        "description": "Export-ready services",
+        "hourly_rate": 75.0,
+        "specialties": ["painting"],
+    }
+    profile_resp = client.post(
+        "api/v1/artisans/profile", json=artisan_profile, headers=artisan_headers
+    )
+    assert profile_resp.status_code == 200
+
+    client_headers = get_auth_headers(client, "export-cli@test.com", "Pass123!", "client")
+
+    completed_booking_resp = client.post(
+        "api/v1/bookings/create",
+        json={
+            "artisan_id": profile_resp.json()["id"],
+            "service": "Wall painting",
+            "estimated_hours": 3,
+            "estimated_cost": 225.0,
+            "date": "2025-01-15T10:00:00",
+            "location": "12 Main St",
+            "notes": "Use matte finish",
+        },
+        headers=client_headers,
+    )
+    assert completed_booking_resp.status_code == 201
+    completed_booking_id = completed_booking_resp.json()["id"]
+
+    pending_booking_resp = client.post(
+        "api/v1/bookings/create",
+        json={
+            "artisan_id": profile_resp.json()["id"],
+            "service": "Ceiling repair",
+            "estimated_hours": 2,
+            "estimated_cost": 180.0,
+            "date": "2025-01-16T09:00:00",
+            "location": "14 Main St",
+            "notes": "Pending job",
+        },
+        headers=client_headers,
+    )
+    assert pending_booking_resp.status_code == 201
+
+    db = TestingSessionLocal()
+    try:
+        artisan = db.query(Artisan).filter(Artisan.id == profile_resp.json()["id"]).first()
+        completed_booking = (
+            db.query(Booking).filter(Booking.id == completed_booking_id).first()
+        )
+        assert artisan is not None
+        assert completed_booking is not None
+        client_id = completed_booking.client_id
+
+        completed_booking.status = BookingStatus.COMPLETED
+        db.add(
+            Payment(
+                booking_id=completed_booking.id,
+                amount=Decimal("225.00"),
+                status=PaymentStatus.RELEASED,
+            )
+        )
+        db.add(
+            Review(
+                booking_id=completed_booking.id,
+                client_id=completed_booking.client_id,
+                artisan_id=artisan.id,
+                rating=5,
+                comment="Excellent work",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    export_resp = client.get("api/v1/artisans/me/export", headers=artisan_headers)
+
+    assert export_resp.status_code == 200
+    assert export_resp.headers["content-type"].startswith("text/csv")
+    assert "attachment;" in export_resp.headers["content-disposition"]
+    assert ".csv" in export_resp.headers["content-disposition"]
+
+    rows = list(csv.DictReader(io.StringIO(export_resp.text)))
+    assert len(rows) == 1
+    assert rows[0] == {
+        "Date": "2025-01-15",
+        "Job Title": "Wall painting",
+        "Client ID": str(client_id),
+        "Amount Earned": "225.00",
+        "Rating": "5",
+    }


### PR DESCRIPTION

- Summary
 Adds GET /api/v1/artisans/me/export to let authenticated artisans download completed job history and earnings as CSV.
 Filters export data to completed jobs only and includes Date , Job Title , Client ID , Amount Earned , and Rating .
 Streams the generated file as a downloadable response from the artisan API surface.

- What Changed
Added CSV export endpoint in artisan.py .
Added service logic to assemble completed-job export rows in artisan.py .
Added API coverage for CSV export behavior in test_crud_endpoints.py .
Implementation Notes
Uses require_artisan to ensure only authenticated artisans can access the export.
Calculates earnings from valid payment records and falls back to booking cost fields when needed.
Pulls per-job rating from the related review record when available.
Returns the file with StreamingResponse and attachment headers.

- Acceptance Criteria
GET /api/v1/artisans/me/export exists.
Completed jobs for the authenticated artisan are queried.
CSV output includes Date , Job Title , Client ID , Amount Earned , and Rating .
Response is downloadable.

- Testing
Added a test that verifies:
completed jobs are exported
non-completed jobs are excluded
CSV response headers and row content are correct

closes #355 