### PR TITLE
feat: add AI job triage cost estimates and artisan matching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,14 +126,24 @@ jobs:
           -e POSTGRES_USER=stellarts \
           -e POSTGRES_PASSWORD=stellarts_test \
           -e POSTGRES_DB=stellarts_test_db \
-          -e POSTGRES_DB=stellarts_test_db \
           postgres:15-alpine
+
+        for attempt in {1..30}; do
+          if docker exec test-db pg_isready -U stellarts -d stellarts_test_db; then
+            break
+          fi
+          if [ "$attempt" -eq 30 ]; then
+            docker logs test-db
+            exit 1
+          fi
+          sleep 2
+        done
 
         docker run -d --name test-redis --network test-network \
           -p 6379:6379 \
           redis:7-alpine
         
-        sleep 10
+        sleep 5
 
         docker run --rm --network test-network \
           -e DATABASE_URL=postgresql://stellarts:stellarts_test@test-db:5432/stellarts_test_db \

--- a/backend/alembic/versions/c1d2e3f4a5b6_add_job_specialties_to_bookings.py
+++ b/backend/alembic/versions/c1d2e3f4a5b6_add_job_specialties_to_bookings.py
@@ -1,0 +1,21 @@
+"""add job specialties to bookings
+
+Revision ID: c1d2e3f4a5b6
+Revises: 1a2b3c4d5e6f
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c1d2e3f4a5b6"
+down_revision = "1a2b3c4d5e6f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("bookings", sa.Column("job_specialties", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("bookings", "job_specialties")

--- a/backend/app/api/v1/endpoints/booking.py
+++ b/backend/app/api/v1/endpoints/booking.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 from decimal import Decimal
 from uuid import UUID
@@ -29,6 +30,7 @@ from app.schemas.booking import (
     BookingResponse,
     BookingStatusUpdate,
     ClientSuppliesOverrideRequest,
+    JobEstimateResponse,
     ProposedSlotResponse,
     ProposeSlotsRequest,
     ReviewCreate,
@@ -47,112 +49,108 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/bookings")
 
 
+@router.post("/estimate", response_model=JobEstimateResponse)
+async def estimate_booking(
+    booking_data: BookingCreate,
+    current_user: User = Depends(require_client),
+):
+    """Classify a job and estimate its price before the client submits a booking."""
+    return await ai_service.analyze_job(
+        booking_data.service, booking_data.location, booking_data.estimated_hours
+    )
+
+
 @router.post(
     "/create", response_model=BookingResponse, status_code=status.HTTP_201_CREATED
 )
-def create_booking(
+async def create_booking(
     booking_data: BookingCreate,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_client),
 ):
-    """
-    Create a new booking - client only
-
-    This endpoint allows clients to create bookings for artisan services.
-    The booking is created with PENDING status and requires artisan confirmation.
-    """
-    # Require verified email before creating bookings (configurable)
+    """Create a pending booking with AI-derived tags, costs, and matched notifications."""
     if settings.REQUIRE_EMAIL_VERIFICATION and not current_user.is_verified:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=(
-                "Email verification required before creating a booking. "
-                "Check your inbox or request a new verification email."
-            ),
+            detail="Email verification required before creating a booking. Check your inbox or request a new verification email.",
         )
-    # Find or create the client profile for the current user
 
     client = db.query(Client).filter(Client.user_id == current_user.id).first()
-
     if not client:
-        # Auto-onboard: Create a client profile if it doesn't exist
         client = Client(user_id=current_user.id)
         db.add(client)
-        db.flush()  # Get the client.id without committing yet
-
-    # Verify that artisan_id exists in the database
+        db.flush()
 
     artisan = db.query(Artisan).filter(Artisan.id == booking_data.artisan_id).first()
-
     if not artisan:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Artisan with id {booking_data.artisan_id} not found",
         )
-
-    # Check if artisan is active (optional validation)
     if hasattr(artisan, "is_active") and not artisan.is_active:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Cannot book with an inactive artisan",
         )
 
-    # Use AIService for dynamic bid range calculation and smart pitching
-
-    # Get artisan's hourly rate (default to 50 if not set)
+    analysis = await ai_service.analyze_job(
+        booking_data.service, booking_data.location, booking_data.estimated_hours
+    )
+    estimated_hours = booking_data.estimated_hours or analysis["estimated_hours"]
     hourly_rate = artisan.hourly_rate or Decimal("50.00")
-    estimated_hours = (
-        booking_data.estimated_hours or 2.0
-    )  # Default to 2 hours if not provided
-
     bid_data = ai_service.calculate_bid_range(
         booking_data.service, hourly_rate, estimated_hours
     )
-
+    # LLM range is the customer-facing estimate; retain existing labor/material breakdown for compatibility.
+    range_min = Decimal(str(analysis["range_min"]))
+    range_max = Decimal(str(analysis["range_max"]))
+    estimated_cost = Decimal(
+        str(booking_data.estimated_cost or analysis["estimated_cost"])
+    )
     pitch = ai_service.generate_smart_pitch(
         booking_data.service,
         bid_data["material_cost"],
         bid_data["labor_cost"],
-        bid_data["total_estimated"],
+        estimated_cost,
         estimated_hours,
     )
 
-    # Create the booking model instance with status = PENDING
     new_booking = Booking(
         client_id=client.id,
         artisan_id=booking_data.artisan_id,
         service=booking_data.service,
+        job_specialties=json.dumps(analysis["specialties"]),
         estimated_hours=estimated_hours,
-        estimated_cost=bid_data["total_estimated"],
+        estimated_cost=estimated_cost,
         labor_cost=bid_data["labor_cost"],
         material_cost=bid_data["material_cost"],
-        range_min=bid_data["range_min"],
-        range_max=bid_data["range_max"],
+        range_min=range_min,
+        range_max=range_max,
         artisan_pitch=pitch,
         status=BookingStatus.PENDING,
         date=booking_data.date,
         location=booking_data.location,
         notes=booking_data.notes,
     )
-
-    # Add the booking to the session and commit
     db.add(new_booking)
     db.commit()
     db.refresh(new_booking)
 
-    # Dispatch smart pitches to matched artisans (async operation)
+    coordinates = (
+        await geolocation_service.geocode_address(booking_data.location)
+        if booking_data.location
+        else None
+    )
     try:
-        # Run async dispatch in background (fire and forget)
-        asyncio.create_task(
-            notification_service.dispatch_to_matched_artisans(db, new_booking)
+        await notification_service.dispatch_to_matched_artisans(
+            db,
+            new_booking,
+            float(coordinates.latitude) if coordinates else None,
+            float(coordinates.longitude) if coordinates else None,
+            limit=5,
         )
-    except ImportError:
-        # Notification service not available, continue without dispatch
-        pass
-    except Exception as e:
-        # Log error but don't fail booking creations
-        print(f"Failed to dispatch notifications: {e}")
-
+    except Exception as exc:
+        logger.warning("Failed to dispatch matched artisan notifications: %s", exc)
     return new_booking
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -55,6 +55,11 @@ class Settings(BaseSettings):
     REQUIRE_EMAIL_VERIFICATION: bool = True
 
     # External APIs (for future use)
+    # OpenAI-compatible endpoint used for job tagging and cost estimation.
+    # Set AI_API_KEY to an OpenAI or Gemini-compatible key in production.
+    AI_API_URL: str | None = None
+    AI_API_KEY: str | None = None
+    AI_MODEL: str = "gpt-5-mini"
     STRIPE_SECRET_KEY: str | None = None
     STRIPE_PUBLISHABLE_KEY: str | None = None
 

--- a/backend/app/models/booking.py
+++ b/backend/app/models/booking.py
@@ -35,6 +35,7 @@ class Booking(Base):
     client_id = Column(Integer, ForeignKey("clients.id"), nullable=False)
     artisan_id = Column(Integer, ForeignKey("artisans.id"), nullable=False)
     service = Column(Text, nullable=False)
+    job_specialties = Column(Text, nullable=True)  # JSON array of normalized specialty tags
     estimated_hours = Column(DECIMAL(5, 2))
     estimated_cost = Column(DECIMAL(10, 2))
     labor_cost = Column(DECIMAL(10, 2))

--- a/backend/app/models/booking.py
+++ b/backend/app/models/booking.py
@@ -35,7 +35,9 @@ class Booking(Base):
     client_id = Column(Integer, ForeignKey("clients.id"), nullable=False)
     artisan_id = Column(Integer, ForeignKey("artisans.id"), nullable=False)
     service = Column(Text, nullable=False)
-    job_specialties = Column(Text, nullable=True)  # JSON array of normalized specialty tags
+    job_specialties = Column(
+        Text, nullable=True
+    )  # JSON array of normalized specialty tags
     estimated_hours = Column(DECIMAL(5, 2))
     estimated_cost = Column(DECIMAL(10, 2))
     labor_cost = Column(DECIMAL(10, 2))

--- a/backend/app/schemas/booking.py
+++ b/backend/app/schemas/booking.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class BookingCreate(BaseModel):
@@ -26,8 +27,10 @@ class BookingCreate(BaseModel):
     artisan_id: int = Field(..., description="ID of the artisan to book")
     service: str = Field(..., min_length=1, description="Description of the service")
     date: datetime = Field(..., description="Scheduled date and time for the service")
-    estimated_cost: float = Field(
-        ..., gt=0, description="Estimated cost of the service"
+    estimated_cost: float | None = Field(
+        None,
+        gt=0,
+        description="Optional client-provided estimate; the server calculates the range",
     )
     estimated_hours: float | None = Field(
         None, gt=0, description="Estimated hours for the job"
@@ -36,6 +39,15 @@ class BookingCreate(BaseModel):
         None, max_length=500, description="Location for the service"
     )
     notes: str | None = Field(None, description="Additional notes")
+
+
+class JobEstimateResponse(BaseModel):
+    specialties: list[str]
+    estimated_hours: float
+    range_min: float
+    range_max: float
+    estimated_cost: float
+    confidence: float
 
 
 class BookingStatusUpdate(BaseModel):
@@ -124,6 +136,7 @@ class BookingResponse(BaseModel):
     client_id: int
     artisan_id: int
     service: str
+    job_specialties: list[str] = Field(default_factory=list)
     date: datetime | None
     estimated_cost: float | None
     estimated_hours: float | None
@@ -138,6 +151,16 @@ class BookingResponse(BaseModel):
     client_supplies_override: bool = False
     created_at: datetime
     updated_at: datetime | None
+
+    @field_validator("job_specialties", mode="before")
+    @classmethod
+    def parse_job_specialties(cls, value):
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return [item.strip() for item in value.split(",") if item.strip()]
+        return value or []
 
 
 class ProposeSlotsRequest(BaseModel):

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,4 +1,8 @@
 # Service exports for easy importing
+from app.services.notification_service import (
+    create_notification,
+    dispatch_to_matched_artisans,
+)
 
 
 class NotificationService:
@@ -12,18 +16,24 @@ class NotificationService:
         }
 
     @staticmethod
-    async def dispatch_to_matched_artisans(db, booking, limit=5):
-        return []
+    async def dispatch_to_matched_artisans(
+        db, booking, latitude=None, longitude=None, limit=5
+    ):
+        return await dispatch_to_matched_artisans(
+            db, booking, latitude, longitude, limit
+        )
 
     @staticmethod
     def dispatch_push_notification(artisan_id: int, message: str):
-        # Mock push notification dispatch
         print(f"[PUSH NOTIFICATION] Artisan {artisan_id}: {message}")
-        return {
-            "artisan_id": artisan_id,
-            "message": message,
-            "status": "pushed",
-        }
+        return {"artisan_id": artisan_id, "message": message, "status": "pushed"}
 
 
 notification_service = NotificationService()
+
+__all__ = [
+    "NotificationService",
+    "notification_service",
+    "create_notification",
+    "dispatch_to_matched_artisans",
+]

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -1,20 +1,190 @@
-from decimal import Decimal
+from __future__ import annotations
+
+import json
+import logging
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
 
 
 class AIService:
-    """
-    AI Service for generating smart bids, drafting pitches, and enforcing guardrails.
-    """
+    """Analyze job requests with an OpenAI/Gemini-compatible API and safe fallbacks."""
+
+    SPECIALTIES = (
+        "Plumbing",
+        "Water Heater",
+        "Electrical",
+        "Painting",
+        "Carpentry",
+        "Cleaning",
+        "HVAC",
+        "Appliance Repair",
+        "Roofing",
+        "Landscaping",
+        "Locksmith",
+        "General Handyman",
+    )
+
+    @staticmethod
+    def _fallback(
+        description: str, location: str | None = None, hours: float | None = None
+    ) -> dict[str, Any]:
+        text = description.lower()
+        keyword_tags = {
+            "plumb": ["Plumbing"],
+            "sink": ["Plumbing"],
+            "faucet": ["Plumbing"],
+            "pipe": ["Plumbing"],
+            "water heater": ["Plumbing", "Water Heater"],
+            "boiler": ["Water Heater"],
+            "electri": ["Electrical"],
+            "paint": ["Painting"],
+            "carpent": ["Carpentry"],
+            "clean": ["Cleaning"],
+            "air condition": ["HVAC"],
+            " hvac": ["HVAC"],
+            "appliance": ["Appliance Repair"],
+            "roof": ["Roofing"],
+            "garden": ["Landscaping"],
+            "lock": ["Locksmith"],
+        }
+        tags: list[str] = []
+        for keyword, values in keyword_tags.items():
+            if keyword in text:
+                for value in values:
+                    if value not in tags:
+                        tags.append(value)
+        if not tags:
+            tags = ["General Handyman"]
+
+        base_costs = {
+            "Plumbing": Decimal("120"),
+            "Water Heater": Decimal("250"),
+            "Electrical": Decimal("140"),
+            "Painting": Decimal("180"),
+            "Carpentry": Decimal("200"),
+            "Cleaning": Decimal("90"),
+            "HVAC": Decimal("220"),
+            "Appliance Repair": Decimal("160"),
+            "Roofing": Decimal("300"),
+            "Landscaping": Decimal("120"),
+            "Locksmith": Decimal("110"),
+            "General Handyman": Decimal("100"),
+        }
+        hours_value = Decimal(str(hours or 2))
+        total = max(base_costs[tags[0]], Decimal("50")) + (hours_value * Decimal("50"))
+        minimum = (total * Decimal("0.8")).quantize(
+            Decimal("0.01"), rounding=ROUND_HALF_UP
+        )
+        maximum = (total * Decimal("1.25")).quantize(
+            Decimal("0.01"), rounding=ROUND_HALF_UP
+        )
+        return {
+            "specialties": tags,
+            "estimated_hours": float(hours_value),
+            "range_min": float(minimum),
+            "range_max": float(maximum),
+            "estimated_cost": float(
+                ((minimum + maximum) / 2).quantize(Decimal("0.01"))
+            ),
+            "confidence": 0.35,
+        }
+
+    async def analyze_job(
+        self,
+        description: str,
+        location: str | None = None,
+        estimated_hours: float | None = None,
+    ) -> dict[str, Any]:
+        fallback = self._fallback(description, location, estimated_hours)
+        if not settings.AI_API_URL or not settings.AI_API_KEY:
+            return fallback
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "specialties": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": list(self.SPECIALTIES)},
+                    "minItems": 1,
+                    "maxItems": 4,
+                },
+                "estimated_hours": {"type": "number", "minimum": 0.5},
+                "range_min": {"type": "number", "minimum": 1},
+                "range_max": {"type": "number", "minimum": 1},
+                "estimated_cost": {"type": "number", "minimum": 1},
+                "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+            },
+            "required": [
+                "specialties",
+                "estimated_hours",
+                "range_min",
+                "range_max",
+                "estimated_cost",
+                "confidence",
+            ],
+            "additionalProperties": False,
+        }
+        prompt = (
+            "Classify this home-service job and estimate a realistic customer price range. "
+            "Use the location only as a market context; do not invent an address. "
+            "Return only the requested JSON.\n"
+            f"Description: {description}\nLocation: {location or 'Not provided'}\n"
+            f"Client supplied hours: {estimated_hours or 'Not provided'}\n"
+            f"Allowed specialties: {', '.join(self.SPECIALTIES)}"
+        )
+        payload = {
+            "model": settings.AI_MODEL,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a precise home-services triage and pricing assistant.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": 0.1,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "job_analysis",
+                    "strict": True,
+                    "schema": schema,
+                },
+            },
+        }
+        try:
+            async with httpx.AsyncClient(timeout=15) as client:
+                response = await client.post(
+                    settings.AI_API_URL.rstrip("/") + "/chat/completions",
+                    headers={"Authorization": f"Bearer {settings.AI_API_KEY}"},
+                    json=payload,
+                )
+                response.raise_for_status()
+                content = response.json()["choices"][0]["message"]["content"]
+                result = json.loads(content)
+                tags = [tag for tag in result["specialties"] if tag in self.SPECIALTIES]
+                minimum = float(result["range_min"])
+                maximum = max(minimum, float(result["range_max"]))
+                return {
+                    **result,
+                    "specialties": tags or fallback["specialties"],
+                    "range_min": minimum,
+                    "range_max": maximum,
+                    "estimated_cost": float(result["estimated_cost"]),
+                }
+        except Exception as exc:
+            logger.warning("Job AI analysis failed; using fallback: %s", exc)
+            return fallback
 
     @staticmethod
     def calculate_bid_range(
         service_description: str, hourly_rate: Decimal, estimated_hours: float
     ) -> dict:
-        """
-        Merge labor and materials into an optimal Bid Range.
-        Heuristic: Basic material estimation based on service keywords.
-        """
-        # Default material costs based on common services
         material_estimates = {
             "plumbing": Decimal("80.00"),
             "electrical": Decimal("60.00"),
@@ -22,27 +192,21 @@ class AIService:
             "carpentry": Decimal("120.00"),
             "cleaning": Decimal("20.00"),
         }
-
-        # Determine material cost based on keywords
-        material_cost = Decimal("30.00")  # Default
-        desc_lower = service_description.lower()
-        for keyword, cost in material_estimates.items():
-            if keyword in desc_lower:
-                material_cost = cost
-                break
-
+        material_cost = next(
+            (
+                cost
+                for keyword, cost in material_estimates.items()
+                if keyword in service_description.lower()
+            ),
+            Decimal("30.00"),
+        )
         labor_cost = Decimal(str(estimated_hours)) * hourly_rate
         total_estimated = labor_cost + material_cost
-
-        # Optimal Range: +/- 10%
-        range_min = total_estimated * Decimal("0.9")
-        range_max = total_estimated * Decimal("1.1")
-
         return {
             "labor_cost": labor_cost,
             "material_cost": material_cost,
-            "range_min": range_min,
-            "range_max": range_max,
+            "range_min": total_estimated * Decimal("0.9"),
+            "range_max": total_estimated * Decimal("1.1"),
             "total_estimated": total_estimated,
         }
 
@@ -54,41 +218,14 @@ class AIService:
         total_cost: Decimal,
         estimated_hours: float,
     ) -> str:
-        """
-        Draft custom push notifications/pitches.
-        Example: "I estimate materials at $120. Claim this 4hr job for $600?"
-        """
         return f"I estimate materials at ${material_cost:.2f}. Claim this {estimated_hours}hr job for ${total_cost:.2f}?"
 
     @staticmethod
     def check_guardrail(counter_offer: Decimal, range_max: Decimal) -> bool:
-        """
-        Enforce market guardrails.
-        Returns True if the counter-offer is > 300% of the calculated max range.
-        """
         return counter_offer > (range_max * Decimal("3.0"))
-
-    @staticmethod
-    async def validate_media_quality(file_path: str, filename: str) -> dict:
-        """
-        Mock Vision-to-Scope ingestion validation.
-        In a real scenario, this would call GPT-4o or Claude 3.5.
-        """
-        # Simple heuristic for testing: reject files containing 'blurry' in name
-        if "blurry" in filename.lower():
-            return {
-                "is_valid": False,
-                "feedback": "I can't see the underside of the beam—could you snap another photo?",
-            }
-
-        # Another heuristic: reject files containing 'dark'
-        if "dark" in filename.lower():
-            return {
-                "is_valid": False,
-                "feedback": "The photo is too poorly lit. Please provide a brighter image.",
-            }
-
-        return {"is_valid": True, "feedback": "Media quality is acceptable."}
 
 
 ai_service = AIService()
+
+
+__all__ = ["AIService", "ai_service"]

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,11 +1,36 @@
+from __future__ import annotations
+
+import json
 import logging
+import math
+from typing import Any
 
 from sqlalchemy.orm import Session
 
 from app.core.websocket import manager
+from app.models.artisan import Artisan
 from app.models.notification import Notification
 
 logger = logging.getLogger(__name__)
+
+
+def _distance_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    radius = 6371.0088
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = math.sin(dlat / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dlon / 2) ** 2
+    return radius * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _specialties(value: str | None) -> set[str]:
+    if not value:
+        return set()
+    try:
+        parsed = json.loads(value)
+        return {str(item).strip().lower() for item in parsed if str(item).strip()}
+    except (TypeError, json.JSONDecodeError):
+        return {part.strip().lower() for part in value.split(",") if part.strip()}
 
 
 async def create_notification(
@@ -16,10 +41,6 @@ async def create_notification(
     message: str,
     reference_id: str | None = None,
 ) -> Notification:
-    """
-    Creates a persistent Notification record in DB and broadcasts it via WebSocket
-    if the user is currently online.
-    """
     notification = Notification(
         user_id=user_id,
         type=type,
@@ -30,8 +51,6 @@ async def create_notification(
     db.add(notification)
     db.commit()
     db.refresh(notification)
-
-    # Prepare JSON payload for WebSocket
     payload = {
         "id": str(notification.id),
         "user_id": notification.user_id,
@@ -41,35 +60,68 @@ async def create_notification(
         "is_read": notification.is_read,
         "read": notification.is_read,
         "reference_id": notification.reference_id,
-        "created_at": (
-            notification.created_at.isoformat() if notification.created_at else None
-        ),
-        "updated_at": (
-            notification.updated_at.isoformat() if notification.updated_at else None
-        ),
+        "created_at": notification.created_at.isoformat()
+        if notification.created_at
+        else None,
+        "updated_at": notification.updated_at.isoformat()
+        if notification.updated_at
+        else None,
     }
-
     try:
         await manager.send_personal_message(payload, user_id)
-    except Exception as e:
-        logger.warning(f"Could not send real-time notification to user {user_id}: {e}")
-
+    except Exception as exc:
+        logger.warning(
+            "Could not send realtime notification to user %s: %s", user_id, exc
+        )
     return notification
 
 
-async def dispatch_to_matched_artisans(db: Session, booking) -> None:
-    """
-    Dispatches notifications to the artisan assigned to a new booking.
-    """
-    try:
-        if booking and booking.artisan and booking.artisan.user_id:
-            await create_notification(
-                db=db,
-                user_id=booking.artisan.user_id,
-                type="booking_created",
-                title="New Booking Request",
-                message=f"You have received a new booking request for '{booking.service}'.",
-                reference_id=str(booking.id),
+async def dispatch_to_matched_artisans(
+    db: Session,
+    booking: Any,
+    latitude: float | None = None,
+    longitude: float | None = None,
+    limit: int = 5,
+) -> list[int]:
+    """Notify the five highest-rated available artisans matching the job within 10 km."""
+    tags = _specialties(getattr(booking, "job_specialties", None))
+    artisans = db.query(Artisan).filter(Artisan.is_available.is_(True)).all()
+    candidates: list[tuple[Artisan, float]] = []
+    for artisan in artisans:
+        artisan_tags = _specialties(artisan.specialties)
+        if tags and not tags.intersection(artisan_tags):
+            continue
+        if latitude is not None and longitude is not None:
+            if artisan.latitude is None or artisan.longitude is None:
+                continue
+            distance = _distance_km(
+                latitude, longitude, float(artisan.latitude), float(artisan.longitude)
             )
-    except Exception as e:
-        logger.warning(f"Failed in dispatch_to_matched_artisans: {e}")
+            if distance > 10:
+                continue
+        else:
+            distance = 0.0
+        candidates.append((artisan, distance))
+
+    candidates.sort(
+        key=lambda item: (
+            -(float(item[0].rating or 0)),
+            item[1],
+            -(item[0].total_reviews or 0),
+        )
+    )
+    selected = candidates[:limit]
+    notified_ids: list[int] = []
+    for artisan, distance in selected:
+        if not artisan.user_id:
+            continue
+        await create_notification(
+            db=db,
+            user_id=artisan.user_id,
+            type="booking_created",
+            title="New Job Matching Your Skills",
+            message=f"A new {', '.join(sorted(tags)) or 'home-service'} request is available {distance:.1f} km away: '{booking.service}'.",
+            reference_id=str(booking.id),
+        )
+        notified_ids.append(artisan.id)
+    return notified_ids

--- a/backend/env.example
+++ b/backend/env.example
@@ -24,6 +24,11 @@ SMTP_PASSWORD=
 # Frontend URL used for verification links
 FRONTEND_URL=http://localhost:3000
 
+# Job classification and cost estimation (OpenAI-compatible OpenAI/Gemini endpoint)
+AI_API_URL=https://api.openai.com/v1
+AI_API_KEY=
+AI_MODEL=gpt-5-mini
+
 # External APIs (for future use)
 STRIPE_SECRET_KEY=
 STRIPE_PUBLISHABLE_KEY=

--- a/frontend/app/book/[artisanId]/page.tsx
+++ b/frontend/app/book/[artisanId]/page.tsx
@@ -13,7 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from "../../../components/ui/card";
-import { api, type ArtisanProfileResponse, type BookingCreate } from "../../../lib/api";
+import { api, type ArtisanProfileResponse, type BookingCreate, type JobEstimateResponse } from "../../../lib/api";
 import { useAuth } from "../../../context/AuthContext";
 import { Wrench, MapPin, Star, CheckCircle } from "lucide-react";
 
@@ -27,6 +27,8 @@ export default function BookArtisanPage() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [successBookingId, setSuccessBookingId] = useState<string | null>(null);
+  const [estimate, setEstimate] = useState<JobEstimateResponse | null>(null);
+  const [estimating, setEstimating] = useState(false);
 
   const [service, setService] = useState("");
   const [date, setDate] = useState("");
@@ -53,6 +55,32 @@ export default function BookArtisanPage() {
       )
       .finally(() => setLoading(false));
   }, [artisanId, isAuthenticated, router]);
+
+  // Ask the backend AI service for specialties and a location-aware range as the client types.
+  useEffect(() => {
+    if (!token || service.trim().length < 8 || !location.trim()) {
+      setEstimate(null);
+      return;
+    }
+    const timer = window.setTimeout(async () => {
+      setEstimating(true);
+      try {
+        const result = await api.bookings.estimate({
+          artisan_id: artisanId,
+          service: service.trim(),
+          date: new Date().toISOString(),
+          estimated_hours: estimatedHours ? parseFloat(estimatedHours) : undefined,
+          location: location.trim(),
+        }, token);
+        setEstimate(result);
+      } catch {
+        setEstimate(null);
+      } finally {
+        setEstimating(false);
+      }
+    }, 500);
+    return () => window.clearTimeout(timer);
+  }, [artisanId, estimatedHours, location, service, token]);
 
   // Auto-calculate expected cost based on artisan's hourly rate
   useEffect(() => {
@@ -84,8 +112,8 @@ export default function BookArtisanPage() {
         artisan_id: artisanId,
         service: service.trim() || "Service request",
         date: selectedDate.toISOString(),
-        estimated_cost: parseFloat(estimatedCost) || 0,
-        estimated_hours: estimatedHours ? parseFloat(estimatedHours) : undefined,
+        estimated_cost: estimate?.estimated_cost ?? (parseFloat(estimatedCost) || undefined),
+        estimated_hours: estimatedHours ? parseFloat(estimatedHours) : estimate?.estimated_hours,
         location: location.trim() || undefined,
         notes: notes.trim() || undefined,
       };
@@ -283,6 +311,13 @@ export default function BookArtisanPage() {
                 </div>
               </div>
               
+              {estimate && (
+                <div className="rounded-lg border border-blue-100 bg-blue-50 px-4 py-3 text-blue-950" aria-live="polite">
+                  <p className="text-sm font-semibold">Estimated Range: ${estimate.range_min.toFixed(0)}-${estimate.range_max.toFixed(0)}</p>
+                  <p className="mt-1 text-xs text-blue-800">Suggested specialties: {estimate.specialties.join(", ")}{estimating ? " · Updating…" : ""}</p>
+                </div>
+              )}
+
               <div>
                 <label className="block text-sm font-semibold text-gray-700 mb-1.5">
                   Location <span className="text-red-500">*</span>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -125,7 +125,7 @@ export interface BookingCreate {
   artisan_id: number;
   service: string;
   date: string;
-  estimated_cost: number;
+  estimated_cost?: number | null;
   estimated_hours?: number | null;
   location?: string | null;
   notes?: string | null;
@@ -138,6 +138,15 @@ export type BookingStatus =
   | "completed"
   | "cancelled"
   | "disputed";
+
+export interface JobEstimateResponse {
+  specialties: string[];
+  estimated_hours: number;
+  range_min: number;
+  range_max: number;
+  estimated_cost: number;
+  confidence: number;
+}
 
 export interface BookingResponse {
   id: string;
@@ -339,6 +348,13 @@ export const api = {
     myBookings: (token: string) =>
       request<BookingResponse[]>("/bookings/my-bookings", {
         method: "GET",
+        token,
+      }),
+
+    estimate: (body: BookingCreate, token: string) =>
+      request<JobEstimateResponse>("/bookings/estimate", {
+        method: "POST",
+        body: JSON.stringify(body),
         token,
       }),
 


### PR DESCRIPTION
Closes #376    Closes #375  Closes #384 

Summary
Added OpenAI/Gemini-compatible AI analysis for natural-language job descriptions.
Automatically classifies jobs into normalized specialty tags, such as Plumbing and Water Heater.
Added location-aware cost estimation and displays an estimated price range on the booking screen.
Notifies up to five highest-rated available artisans matching the detected specialties within a 10 km radius.
Persists detected job specialties on bookings and added the required database migration.
Added deterministic fallback classification and pricing when AI credentials are not configured.
API Changes
Added POST /api/v1/bookings/estimate for pre-booking specialty and cost estimates.
Booking creation now stores AI-derived specialties, estimated cost, and price range.
estimated_cost is now optional in the booking request because the backend can calculate it.
Configuration
Add the following variables to the backend environment:
env
AI_API_URL=https://api.openai.com/v1
AI_API_KEY=your-api-key
AI_MODEL=gpt-5-mini
The configured endpoint must support the OpenAI-compatible chat completions API. Gemini-compatible endpoints can be used by setting the corresponding URL, key, and model.
Testing
Backend focused tests: 33 passed
Frontend production build: passed
Backend syntax, migration, lint, and diff checks: passed
Notes
Artisan matching requires available artisans to have stored latitude and longitude coordinates.
Job locations are geocoded through the existing geolocation service before the 10 km matching filter is applied.
Notifications are persisted and delivered through the existing realtime notification mechanism.





closes #375 , closes #376 