### PR TITLE
Replace simple reputation average with EMA recency weighting

### DIFF
--- a/contracts/dispute_resolution/src/lib.rs
+++ b/contracts/dispute_resolution/src/lib.rs
@@ -13,7 +13,7 @@
 //! the caller (dispute party or admin). Every candidate is verified on-chain:
 //!
 //! * rating must be strictly greater than 4.5 (queried from the registered
-//!   `reputation` contract; `total_stars * 2 > review_count * 9`),
+//!   `reputation` contract; `ema_scaled > 45_000`, i.e. EMA strictly above 4.5 stars),
 //! * the artisan must not be a party to the dispute (client or artisan),
 //! * no duplicate addresses.
 //!
@@ -190,7 +190,7 @@ pub struct EscrowEngagement {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReputationData {
-    pub total_stars: u64,
+    pub ema_scaled: u64,
     pub review_count: u64,
 }
 
@@ -254,10 +254,10 @@ impl DisputeResolutionContract {
     }
 
     /// Whether `artisan` is eligible for jury duty for this dispute:
-    /// strictly more than 4.5 average rating and not a party to the dispute.
+    /// strictly more than 4.5 EMA rating and not a party to the dispute.
     ///
-    /// Average rating is compared with integer math only:
-    /// `average > 4.5`  ⇔  `total_stars * 2 > review_count * 9`.
+    /// EMA is compared with integer math only:
+    /// `average > 4.5`  ⇔  `ema_scaled > 45_000` (scale × 10_000).
     fn is_eligible(env: &Env, artisan: &Address, dispute: &Dispute) -> bool {
         if artisan == &dispute.client || artisan == &dispute.artisan {
             return false;
@@ -267,11 +267,7 @@ impl DisputeResolutionContract {
         if reputation.review_count == 0 {
             return false;
         }
-        reputation
-            .total_stars
-            .checked_mul(2)
-            .and_then(|n| reputation.review_count.checked_mul(9).map(|d| n > d))
-            .unwrap_or(false)
+        reputation.ema_scaled > 45_000
     }
 
     /// Set the contract admin. Can only be called once.

--- a/contracts/dispute_resolution/src/test.rs
+++ b/contracts/dispute_resolution/src/test.rs
@@ -86,13 +86,13 @@ impl Ctx {
         }
     }
 
-    /// Seed an artisan's on-chain reputation (total stars / review count).
-    fn seed_artisan(&self, artisan: &Address, total_stars: u64, review_count: u64) {
+    /// Seed an artisan's on-chain reputation (EMA scaled × 10_000 / review count).
+    fn seed_artisan(&self, artisan: &Address, ema_scaled: u64, review_count: u64) {
         self.rep_client.set_reputation(
             &self.admin,
             artisan,
             &reputation::ReputationData {
-                total_stars,
+                ema_scaled,
                 review_count,
             },
         );
@@ -101,7 +101,7 @@ impl Ctx {
     /// Seed a 5.0-star rated artisan.
     fn seed_rated_artisan(&self) -> Address {
         let artisan = Address::generate(&self.env);
-        self.seed_artisan(&artisan, 5, 1);
+        self.seed_artisan(&artisan, 50_000, 1);
         artisan
     }
 
@@ -322,7 +322,7 @@ fn test_rating_exactly_4_5_rejected() {
     let (id, client, _) = ctx.setup_dispute(1_000);
 
     let exactly_4_5 = Address::generate(&ctx.env);
-    ctx.seed_artisan(&exactly_4_5, 9, 2); // 4.5 average
+    ctx.seed_artisan(&exactly_4_5, 45_000, 2); // exactly 4.5 EMA
 
     let a = ctx.seed_rated_artisan();
     let b = ctx.seed_rated_artisan();
@@ -344,7 +344,7 @@ fn test_rating_below_4_5_rejected() {
     let (id, client, _) = ctx.setup_dispute(1_000);
 
     let below = Address::generate(&ctx.env);
-    ctx.seed_artisan(&below, 4, 1); // 4.0 average
+    ctx.seed_artisan(&below, 40_000, 1); // 4.0 EMA
     let unrated = Address::generate(&ctx.env); // no reviews at all
 
     let a = ctx.seed_rated_artisan();
@@ -368,7 +368,7 @@ fn test_rating_above_4_5_eligible() {
     let (id, client, _) = ctx.setup_dispute(1_000);
 
     let above = Address::generate(&ctx.env);
-    ctx.seed_artisan(&above, 14, 3); // 4.666… average
+    ctx.seed_artisan(&above, 47_000, 3); // above 4.5 EMA
 
     let a = ctx.seed_rated_artisan();
     let b = ctx.seed_rated_artisan();
@@ -459,7 +459,7 @@ fn test_select_jury_not_enough_eligible_fails() {
     let a = ctx.seed_rated_artisan();
     let b = ctx.seed_rated_artisan();
     let low = Address::generate(&ctx.env);
-    ctx.seed_artisan(&low, 4, 1);
+    ctx.seed_artisan(&low, 40_000, 1);
     ctx.select_jury(id, &vec![&ctx.env, a, b, low], &client);
 }
 

--- a/contracts/dispute_resolution/test_snapshots/test/test_create_dispute_by_artisan.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_create_dispute_by_artisan.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1075,18 +1075,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2301,18 +2301,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_create_dispute_duplicate_registration_fails.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_create_dispute_duplicate_registration_fails.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1075,18 +1075,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2301,18 +2301,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_create_dispute_registers_dispute.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_create_dispute_registers_dispute.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1076,18 +1076,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2302,18 +2302,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_create_dispute_requires_disputed_escrow.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_create_dispute_requires_disputed_escrow.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1032,18 +1032,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2075,18 +2075,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_create_dispute_unauthorized_caller_fails.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_create_dispute_unauthorized_caller_fails.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1053,18 +1053,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2129,18 +2129,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_dispute_parties_cannot_be_jurors.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_dispute_parties_cannot_be_jurors.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1341,18 +1341,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1403,18 +1403,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1465,18 +1465,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1527,18 +1527,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2796,18 +2796,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3715,18 +3715,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3789,18 +3789,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3863,18 +3863,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4004,18 +4004,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4070,18 +4070,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4136,18 +4136,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_duplicate_vote_fails.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_duplicate_vote_fails.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1364,18 +1364,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1426,18 +1426,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1488,18 +1488,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1550,18 +1550,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2907,18 +2907,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3826,18 +3826,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3900,18 +3900,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3974,18 +3974,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4109,18 +4109,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4175,18 +4175,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4241,18 +4241,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_escrow_balances_conserved_after_resolution.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_escrow_balances_conserved_after_resolution.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1463,18 +1463,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1525,18 +1525,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1587,18 +1587,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1649,18 +1649,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3629,18 +3629,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4548,18 +4548,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4622,18 +4622,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4696,18 +4696,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4831,18 +4831,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4897,18 +4897,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4963,18 +4963,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_favor_client_pays_no_rewards.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_favor_client_pays_no_rewards.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1463,18 +1463,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1525,18 +1525,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1587,18 +1587,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1649,18 +1649,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3264,18 +3264,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4183,18 +4183,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4257,18 +4257,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4331,18 +4331,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4466,18 +4466,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4532,18 +4532,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4598,18 +4598,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_finalize_after_resolved_fails.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_finalize_after_resolved_fails.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1456,18 +1456,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1518,18 +1518,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1580,18 +1580,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1642,18 +1642,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3257,18 +3257,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4176,18 +4176,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4250,18 +4250,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4324,18 +4324,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4459,18 +4459,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4525,18 +4525,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4591,18 +4591,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_finalize_allows_juror_caller.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_finalize_allows_juror_caller.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1457,18 +1457,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1519,18 +1519,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1581,18 +1581,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1643,18 +1643,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3696,18 +3696,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4615,18 +4615,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4689,18 +4689,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4763,18 +4763,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4898,18 +4898,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4964,18 +4964,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -5030,18 +5030,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_finalize_before_jury_selected_fails.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_finalize_before_jury_selected_fails.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1075,18 +1075,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2301,18 +2301,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_finalize_majority_favor_artisan.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_finalize_majority_favor_artisan.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1463,18 +1463,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1525,18 +1525,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1587,18 +1587,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1649,18 +1649,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3629,18 +3629,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4548,18 +4548,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4622,18 +4622,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4696,18 +4696,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4831,18 +4831,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4897,18 +4897,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4963,18 +4963,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_finalize_majority_favor_client.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_finalize_majority_favor_client.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1462,18 +1462,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1524,18 +1524,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1586,18 +1586,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1648,18 +1648,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3263,18 +3263,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4182,18 +4182,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4256,18 +4256,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4330,18 +4330,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4465,18 +4465,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4531,18 +4531,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4597,18 +4597,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_finalize_majority_split.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_finalize_majority_split.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1462,18 +1462,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1524,18 +1524,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1586,18 +1586,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1648,18 +1648,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3628,18 +3628,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4547,18 +4547,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4621,18 +4621,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4695,18 +4695,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4830,18 +4830,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4896,18 +4896,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4962,18 +4962,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_finalize_not_all_voted_fails.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_finalize_not_all_voted_fails.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1393,18 +1393,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1455,18 +1455,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1517,18 +1517,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1579,18 +1579,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3024,18 +3024,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3943,18 +3943,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4017,18 +4017,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4091,18 +4091,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4226,18 +4226,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4292,18 +4292,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4358,18 +4358,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_finalize_split_odd_remaining.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_finalize_split_odd_remaining.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1461,18 +1461,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1523,18 +1523,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1585,18 +1585,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1647,18 +1647,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3627,18 +3627,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4546,18 +4546,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4620,18 +4620,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4694,18 +4694,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4829,18 +4829,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4895,18 +4895,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4961,18 +4961,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_finalize_tie_fails.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_finalize_tie_fails.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1422,18 +1422,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1484,18 +1484,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1546,18 +1546,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1608,18 +1608,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3141,18 +3141,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4060,18 +4060,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4134,18 +4134,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4208,18 +4208,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4343,18 +4343,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4409,18 +4409,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4475,18 +4475,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_finalize_unauthorized_caller_fails.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_finalize_unauthorized_caller_fails.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1422,18 +1422,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1484,18 +1484,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1546,18 +1546,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1608,18 +1608,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3141,18 +3141,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4060,18 +4060,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4134,18 +4134,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4208,18 +4208,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4343,18 +4343,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4409,18 +4409,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4475,18 +4475,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_juror_vote_succeeds.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_juror_vote_succeeds.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1364,18 +1364,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1426,18 +1426,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1488,18 +1488,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1550,18 +1550,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2907,18 +2907,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3826,18 +3826,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3900,18 +3900,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3974,18 +3974,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4109,18 +4109,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4175,18 +4175,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4241,18 +4241,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_large_amounts_no_overflow.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_large_amounts_no_overflow.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1462,18 +1462,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1524,18 +1524,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1586,18 +1586,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1648,18 +1648,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3701,18 +3701,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4620,18 +4620,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4694,18 +4694,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4768,18 +4768,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4903,18 +4903,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4969,18 +4969,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -5035,18 +5035,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_majority_jurors_receive_reward_minority_none.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_majority_jurors_receive_reward_minority_none.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1459,18 +1459,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1521,18 +1521,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1583,18 +1583,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1645,18 +1645,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3625,18 +3625,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4544,18 +4544,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4618,18 +4618,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4692,18 +4692,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4827,18 +4827,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4893,18 +4893,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4959,18 +4959,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_no_reward_without_treasury.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_no_reward_without_treasury.1.json
@@ -128,18 +128,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -286,18 +286,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -328,18 +328,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -370,18 +370,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1254,18 +1254,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1316,18 +1316,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1378,18 +1378,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1440,18 +1440,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2980,18 +2980,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3899,18 +3899,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3973,18 +3973,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4047,18 +4047,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4182,18 +4182,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4248,18 +4248,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4314,18 +4314,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_non_juror_vote_fails.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_non_juror_vote_fails.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1335,18 +1335,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1397,18 +1397,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1459,18 +1459,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1521,18 +1521,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2790,18 +2790,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3709,18 +3709,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3783,18 +3783,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3857,18 +3857,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3992,18 +3992,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4058,18 +4058,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4124,18 +4124,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_rating_above_4_5_eligible.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_rating_above_4_5_eligible.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 3
+                        "u64": 47000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 14
+                        "u64": 3
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1335,18 +1335,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1397,18 +1397,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 3
+                        "u64": 47000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 14
+                        "u64": 3
                       }
                     }
                   ]
@@ -1459,18 +1459,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1521,18 +1521,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2790,18 +2790,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3709,18 +3709,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 3
+                        "u64": 47000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 14
+                        "u64": 3
                       }
                     }
                   ]
@@ -3783,18 +3783,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3857,18 +3857,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3992,18 +3992,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 3
+                    "u64": 47000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 14
+                    "u64": 3
                   }
                 }
               ]
@@ -4058,18 +4058,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4124,18 +4124,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_rating_below_4_5_rejected.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_rating_below_4_5_rejected.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 40000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 4
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -459,18 +459,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1416,18 +1416,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1478,18 +1478,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 40000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 4
+                        "u64": 1
                       }
                     }
                   ]
@@ -1540,18 +1540,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1602,18 +1602,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1664,18 +1664,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2933,18 +2933,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3852,18 +3852,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 40000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 4
+                        "u64": 1
                       }
                     }
                   ]
@@ -3926,18 +3926,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4000,18 +4000,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4074,18 +4074,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4215,18 +4215,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 40000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 4
+                    "u64": 1
                   }
                 }
               ]
@@ -4281,7 +4281,7 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
                     "u64": 0
@@ -4289,7 +4289,7 @@
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
                     "u64": 0
@@ -4347,18 +4347,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4413,18 +4413,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4479,18 +4479,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_rating_exactly_4_5_rejected.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_rating_exactly_4_5_rejected.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 2
+                        "u64": 45000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 9
+                        "u64": 2
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -459,18 +459,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1413,18 +1413,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1475,18 +1475,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 2
+                        "u64": 45000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 9
+                        "u64": 2
                       }
                     }
                   ]
@@ -1537,18 +1537,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1599,18 +1599,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1661,18 +1661,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2930,18 +2930,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3849,18 +3849,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 2
+                        "u64": 45000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 9
+                        "u64": 2
                       }
                     }
                   ]
@@ -3923,18 +3923,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3997,18 +3997,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4071,18 +4071,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4209,18 +4209,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 2
+                    "u64": 45000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 9
+                    "u64": 2
                   }
                 }
               ]
@@ -4275,18 +4275,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4341,18 +4341,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4407,18 +4407,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_rewards_distributed_exactly_once.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_rewards_distributed_exactly_once.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1459,18 +1459,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1521,18 +1521,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1583,18 +1583,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1645,18 +1645,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3698,18 +3698,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4617,18 +4617,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4691,18 +4691,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4765,18 +4765,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4900,18 +4900,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4966,18 +4966,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -5032,18 +5032,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_select_jury_allows_admin.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_select_jury_allows_admin.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1368,18 +1368,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1430,18 +1430,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1492,18 +1492,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1554,18 +1554,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2790,18 +2790,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3709,18 +3709,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3783,18 +3783,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3857,18 +3857,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3992,18 +3992,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4058,18 +4058,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4124,18 +4124,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_select_jury_cannot_be_repeated.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_select_jury_cannot_be_repeated.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -494,18 +494,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -536,18 +536,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -578,18 +578,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1560,18 +1560,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1622,18 +1622,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1684,18 +1684,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1746,18 +1746,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1808,18 +1808,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1870,18 +1870,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1932,18 +1932,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3201,18 +3201,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4120,18 +4120,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4194,18 +4194,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4268,18 +4268,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4403,18 +4403,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4469,18 +4469,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4535,18 +4535,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4657,18 +4657,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4731,18 +4731,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4805,18 +4805,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_select_jury_deduplicates_candidates.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_select_jury_deduplicates_candidates.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1341,18 +1341,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1403,18 +1403,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1465,18 +1465,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1527,18 +1527,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2796,18 +2796,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3715,18 +3715,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3789,18 +3789,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3863,18 +3863,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4004,18 +4004,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4070,18 +4070,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4136,18 +4136,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4202,18 +4202,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4268,18 +4268,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_select_jury_not_enough_eligible_fails.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_select_jury_not_enough_eligible_fails.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 40000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 4
+                        "u64": 1
                       }
                     }
                   ]
@@ -1300,18 +1300,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1362,18 +1362,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1424,18 +1424,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1486,18 +1486,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 40000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 4
+                        "u64": 1
                       }
                     }
                   ]
@@ -2712,18 +2712,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3631,18 +3631,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3705,18 +3705,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3779,18 +3779,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 40000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 4
+                        "u64": 1
                       }
                     }
                   ]
@@ -3914,18 +3914,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -3980,18 +3980,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4046,18 +4046,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 40000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 4
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_select_jury_requires_registered_dispute.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_select_jury_requires_registered_dispute.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1300,18 +1300,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1362,18 +1362,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1424,18 +1424,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1486,18 +1486,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2712,18 +2712,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3631,18 +3631,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3705,18 +3705,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3779,18 +3779,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_select_jury_selects_exactly_three_unique_jurors.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_select_jury_selects_exactly_three_unique_jurors.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -459,18 +459,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -501,18 +501,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1492,18 +1492,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1554,18 +1554,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1616,18 +1616,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1678,18 +1678,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1740,18 +1740,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1802,18 +1802,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3071,18 +3071,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3990,18 +3990,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4064,18 +4064,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4138,18 +4138,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4212,18 +4212,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4286,18 +4286,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -4427,18 +4427,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4493,18 +4493,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4559,18 +4559,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4625,18 +4625,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]
@@ -4691,18 +4691,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_select_jury_unauthorized_caller_fails.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_select_jury_unauthorized_caller_fails.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -375,18 +375,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -417,18 +417,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1300,18 +1300,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1362,18 +1362,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1424,18 +1424,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1486,18 +1486,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2712,18 +2712,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3631,18 +3631,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3705,18 +3705,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3779,18 +3779,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_vote_before_jury_selected_fails.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_vote_before_jury_selected_fails.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -333,18 +333,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1150,18 +1150,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1212,18 +1212,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -2438,18 +2438,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -3357,18 +3357,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/dispute_resolution/test_snapshots/test/test_vote_unregistered_dispute_fails.1.json
+++ b/contracts/dispute_resolution/test_snapshots/test/test_vote_unregistered_dispute_fails.1.json
@@ -175,18 +175,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -759,18 +759,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -1623,18 +1623,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -23,12 +23,57 @@ pub struct RateArtisanEvent {
     pub timestamp: u64,
 }
 
+/// Fixed-point scale for the exponential moving average (4.5 stars → 45_000).
+pub const EMA_SCALE: u64 = 10_000;
+/// Weight applied to the previous EMA (0.8 × EMA_SCALE).
+const EMA_OLD_WEIGHT: u64 = 8_000;
+/// Weight applied to the incoming rating (0.2 × EMA_SCALE).
+const EMA_NEW_WEIGHT: u64 = 2_000;
+
 /// Public struct containing aggregated review data for a user.
+///
+/// `ema_scaled` stores the recency-weighted average as `average × EMA_SCALE`
+/// using integer math only (no floating point).
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct ReputationData {
-    pub total_stars: u64,
+    pub ema_scaled: u64,
     pub review_count: u64,
+}
+
+/// Apply one rating to `data` using EMA: `new = old × 0.8 + rating × 0.2`.
+pub fn apply_rating(data: &mut ReputationData, stars: u64) {
+    if data.review_count == 0 {
+        data.ema_scaled = stars.saturating_mul(EMA_SCALE);
+    } else {
+        let weighted_old = data
+            .ema_scaled
+            .saturating_mul(EMA_OLD_WEIGHT)
+            .saturating_div(EMA_SCALE);
+        let weighted_new = stars
+            .saturating_mul(EMA_SCALE)
+            .saturating_mul(EMA_NEW_WEIGHT)
+            .saturating_div(EMA_SCALE);
+        data.ema_scaled = weighted_old.saturating_add(weighted_new);
+    }
+    data.review_count = data.review_count.saturating_add(1);
+}
+
+/// Return the EMA as an average scaled by 100 (4.25 stars → 425).
+pub fn average_scaled_by_100(data: &ReputationData) -> u64 {
+    if data.review_count == 0 {
+        return 0;
+    }
+    data.ema_scaled / 100
+}
+
+/// Simple arithmetic mean scaled by 100, for comparison in tests only.
+#[cfg(test)]
+pub fn simple_mean_scaled_by_100(total_stars: u64, review_count: u64) -> u64 {
+    if review_count == 0 {
+        return 0;
+    }
+    (total_stars.saturating_mul(100)).saturating_div(review_count)
 }
 
 /// A single, individual rating left for an artisan.
@@ -78,7 +123,7 @@ pub trait EscrowVerifier {
 }
 
 /// Helper function to read reputation data for a user.
-/// Returns default values (0 total_stars, 0 review_count) if user has no existing reputation.
+/// Returns default values (0 ema_scaled, 0 review_count) if user has no existing reputation.
 pub fn read_reputation(env: &Env, user: &Address) -> ReputationData {
     let key = DataKey::Reputation(user.clone());
     env.storage().persistent().get(&key).unwrap_or_default()
@@ -243,8 +288,7 @@ impl ReputationContract {
         }
 
         let mut artisan_data = Self::get_reputation(env.clone(), artisan.clone());
-        artisan_data.total_stars += stars;
-        artisan_data.review_count += 1;
+        apply_rating(&mut artisan_data, stars);
 
         write_reputation(&env, &artisan, &artisan_data);
         mark_caller_rated_artisan(&env, &caller, &artisan);
@@ -272,14 +316,10 @@ impl ReputationContract {
     }
 
     /// Get reputation statistics for a user.
-    /// Returns (average_scaled_by_100, count).
+    /// Returns (ema_average_scaled_by_100, count).
     pub fn get_stats(env: Env, user: Address) -> (u64, u64) {
         let data = read_reputation(&env, &user);
-        if data.review_count == 0 {
-            return (0, 0);
-        }
-        let average_scaled = (data.total_stars * 100) / data.review_count;
-        (average_scaled, data.review_count)
+        (average_scaled_by_100(&data), data.review_count)
     }
 
     /// Get the total number of individual ratings recorded for a user.
@@ -369,7 +409,7 @@ mod tests {
     #[test]
     fn test_default_reputation_data() {
         let default = ReputationData::default();
-        assert_eq!(default.total_stars, 0);
+        assert_eq!(default.ema_scaled, 0);
         assert_eq!(default.review_count, 0);
     }
 
@@ -381,7 +421,7 @@ mod tests {
         let user = Address::generate(&env);
         let reputation = client.get_reputation(&user);
 
-        assert_eq!(reputation.total_stars, 0);
+        assert_eq!(reputation.ema_scaled, 0);
         assert_eq!(reputation.review_count, 0);
     }
 
@@ -393,14 +433,14 @@ mod tests {
 
         let user = Address::generate(&env);
         let data = ReputationData {
-            total_stars: 100,
+            ema_scaled: 50_000,
             review_count: 20,
         };
 
         client.set_reputation(&admin, &user, &data);
         let retrieved = client.get_reputation(&user);
 
-        assert_eq!(retrieved.total_stars, 100);
+        assert_eq!(retrieved.ema_scaled, 50_000);
         assert_eq!(retrieved.review_count, 20);
     }
 
@@ -417,7 +457,7 @@ mod tests {
             &admin,
             &user1,
             &ReputationData {
-                total_stars: 50,
+                ema_scaled: 50_000,
                 review_count: 10,
             },
         );
@@ -425,7 +465,7 @@ mod tests {
             &admin,
             &user2,
             &ReputationData {
-                total_stars: 75,
+                ema_scaled: 50_000,
                 review_count: 15,
             },
         );
@@ -433,9 +473,9 @@ mod tests {
         let retrieved1 = client.get_reputation(&user1);
         let retrieved2 = client.get_reputation(&user2);
 
-        assert_eq!(retrieved1.total_stars, 50);
+        assert_eq!(retrieved1.ema_scaled, 50_000);
         assert_eq!(retrieved1.review_count, 10);
-        assert_eq!(retrieved2.total_stars, 75);
+        assert_eq!(retrieved2.ema_scaled, 50_000);
         assert_eq!(retrieved2.review_count, 15);
     }
 
@@ -450,7 +490,7 @@ mod tests {
             &admin,
             &user,
             &ReputationData {
-                total_stars: 30,
+                ema_scaled: 30_000,
                 review_count: 5,
             },
         );
@@ -459,13 +499,13 @@ mod tests {
             &admin,
             &user,
             &ReputationData {
-                total_stars: 80,
+                ema_scaled: 40_000,
                 review_count: 12,
             },
         );
 
         let retrieved = client.get_reputation(&user);
-        assert_eq!(retrieved.total_stars, 80);
+        assert_eq!(retrieved.ema_scaled, 40_000);
         assert_eq!(retrieved.review_count, 12);
     }
 
@@ -496,7 +536,7 @@ mod tests {
         );
 
         let reputation = client.get_reputation(&artisan);
-        assert_eq!(reputation.total_stars, 5);
+        assert_eq!(reputation.ema_scaled, 50_000);
         assert_eq!(reputation.review_count, 1);
     }
 
@@ -686,7 +726,7 @@ mod tests {
             &admin,
             &artisan,
             &ReputationData {
-                total_stars: 9,
+                ema_scaled: 45_000,
                 review_count: 2,
             },
         );
@@ -758,7 +798,7 @@ mod tests {
             &admin,
             &user,
             &ReputationData {
-                total_stars: 10,
+                ema_scaled: 50_000,
                 review_count: 2,
             },
         );
@@ -969,6 +1009,72 @@ mod tests {
         assert_eq!(rating.stars, 4);
         assert_eq!(rating.rater, reviewer);
         assert_eq!(rating.timestamp, env.ledger().timestamp());
+    }
+
+    #[test]
+    fn test_ema_first_rating_is_exact_score() {
+        let mut data = ReputationData::default();
+        apply_rating(&mut data, 4);
+        assert_eq!(data.ema_scaled, 40_000);
+        assert_eq!(data.review_count, 1);
+        assert_eq!(average_scaled_by_100(&data), 400);
+    }
+
+    #[test]
+    fn test_ema_formula_matches_80_20_weighting() {
+        let mut data = ReputationData {
+            ema_scaled: 50_000,
+            review_count: 1,
+        };
+        apply_rating(&mut data, 1);
+        // (50000 * 0.8) + (1 * 0.2) = 40000 + 2000 = 42000
+        assert_eq!(data.ema_scaled, 42_000);
+        assert_eq!(average_scaled_by_100(&data), 420);
+    }
+
+    #[test]
+    fn test_ema_recent_one_star_drops_faster_than_simple_mean() {
+        let mut data = ReputationData::default();
+        let mut simple_total = 0u64;
+        let review_count = 20u64;
+
+        for _ in 0..review_count {
+            apply_rating(&mut data, 5);
+            simple_total += 5;
+        }
+
+        let simple_mean_before = simple_mean_scaled_by_100(simple_total, review_count);
+        assert_eq!(simple_mean_before, 500);
+        assert_eq!(average_scaled_by_100(&data), 500);
+
+        apply_rating(&mut data, 1);
+        simple_total += 1;
+
+        let ema_after = average_scaled_by_100(&data);
+        let simple_mean_after =
+            simple_mean_scaled_by_100(simple_total, review_count.saturating_add(1));
+
+        // EMA: (50000 * 0.8) + (10000 * 0.2) = 42000 → 420 scaled
+        assert_eq!(ema_after, 420);
+        // Simple mean: (100 + 1) / 21 ≈ 4.81 → 480 scaled
+        assert_eq!(simple_mean_after, 480);
+        assert!(
+            ema_after < simple_mean_after,
+            "EMA ({ema_after}) should penalize a recent 1-star more than simple mean ({simple_mean_after})"
+        );
+    }
+
+    #[test]
+    fn test_ema_new_rating_has_twenty_percent_influence() {
+        let old_ema = 40_000u64;
+        let mut data = ReputationData {
+            ema_scaled: old_ema,
+            review_count: 5,
+        };
+        apply_rating(&mut data, 5);
+        let expected = old_ema * 8 / 10 + 5 * EMA_SCALE * 2 / 10;
+        assert_eq!(data.ema_scaled, expected);
+        assert_eq!(data.ema_scaled, 42_000);
     }
 }
 

--- a/contracts/reputation/src/test.rs
+++ b/contracts/reputation/src/test.rs
@@ -74,10 +74,11 @@ fn test_reputation_flow_integration() {
     client.rate_artisan(&client_b, &artisan, &3, &escrow_contract_id, &2);
 
     let stats = client.get_stats(&artisan);
-    assert_eq!(stats, (400, 2));
+    // EMA: 5 then 3 → (50000 * 0.8) + (30000 * 0.2) = 46000 → 460 scaled
+    assert_eq!(stats, (460, 2));
 
     let reputation = client.get_reputation(&artisan);
-    assert_eq!(reputation.total_stars, 8);
+    assert_eq!(reputation.ema_scaled, 46_000);
     assert_eq!(reputation.review_count, 2);
 }
 
@@ -112,11 +113,12 @@ fn test_reputation_robustness_multiple_reviews() {
 
     let stats = client.get_stats(&artisan);
     assert_eq!(stats.1, 10);
-    assert_eq!(stats.0, 430);
+    // EMA over [5,4,5,3,5,4,5,5,4,3] — recency-weighted, not simple 430 mean
+    assert_eq!(stats.0, 421);
 
     let reputation = client.get_reputation(&artisan);
-    assert_eq!(reputation.total_stars, 43);
     assert_eq!(reputation.review_count, 10);
+    assert!(reputation.ema_scaled > 0);
 }
 
 #[test]
@@ -161,14 +163,15 @@ fn test_reputation_isolation_between_artisans() {
     client.rate_artisan(&client_1b, &artisan1, &3, &escrow_contract_id, &2);
     client.rate_artisan(&client_2a, &artisan2, &4, &escrow_contract_id, &3);
 
-    assert_eq!(client.get_stats(&artisan1), (400, 2));
+    // artisan1: 5 then 3 → EMA 460; artisan2: single 4 → 400
+    assert_eq!(client.get_stats(&artisan1), (460, 2));
     assert_eq!(client.get_stats(&artisan2), (400, 1));
 
     let rep1 = client.get_reputation(&artisan1);
     let rep2 = client.get_reputation(&artisan2);
-    assert_eq!(rep1.total_stars, 8);
+    assert_eq!(rep1.ema_scaled, 46_000);
     assert_eq!(rep1.review_count, 2);
-    assert_eq!(rep2.total_stars, 4);
+    assert_eq!(rep2.ema_scaled, 40_000);
     assert_eq!(rep2.review_count, 1);
 }
 

--- a/contracts/reputation/test_snapshots/test/test_reputation_flow_integration.1.json
+++ b/contracts/reputation/test_snapshots/test/test_reputation_flow_integration.1.json
@@ -561,18 +561,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 2
+                        "u64": 46000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 8
+                        "u64": 2
                       }
                     }
                   ]
@@ -1510,7 +1510,7 @@
             "data": {
               "vec": [
                 {
-                  "u64": 400
+                  "u64": 460
                 },
                 {
                   "u64": 2
@@ -1567,18 +1567,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 2
+                    "u64": 46000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 8
+                    "u64": 2
                   }
                 }
               ]

--- a/contracts/reputation/test_snapshots/test/test_reputation_flow_with_paginated_ratings.1.json
+++ b/contracts/reputation/test_snapshots/test/test_reputation_flow_with_paginated_ratings.1.json
@@ -1615,18 +1615,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 7
+                        "u64": 34265
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 24
+                        "u64": 7
                       }
                     }
                   ]

--- a/contracts/reputation/test_snapshots/test/test_reputation_isolation_between_artisans.1.json
+++ b/contracts/reputation/test_snapshots/test/test_reputation_isolation_between_artisans.1.json
@@ -818,18 +818,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 2
+                        "u64": 46000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 8
+                        "u64": 2
                       }
                     }
                   ]
@@ -880,18 +880,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 40000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 4
+                        "u64": 1
                       }
                     }
                   ]
@@ -2226,7 +2226,7 @@
             "data": {
               "vec": [
                 {
-                  "u64": 400
+                  "u64": 460
                 },
                 {
                   "u64": 2
@@ -2339,18 +2339,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 2
+                    "u64": 46000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 8
+                    "u64": 2
                   }
                 }
               ]
@@ -2405,18 +2405,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 40000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 4
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/reputation/test_snapshots/test/test_reputation_robustness_multiple_reviews.1.json
+++ b/contracts/reputation/test_snapshots/test/test_reputation_robustness_multiple_reviews.1.json
@@ -2241,18 +2241,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 10
+                        "u64": 42195
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 43
+                        "u64": 10
                       }
                     }
                   ]
@@ -6366,7 +6366,7 @@
             "data": {
               "vec": [
                 {
-                  "u64": 430
+                  "u64": 421
                 },
                 {
                   "u64": 10
@@ -6423,18 +6423,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 10
+                    "u64": 42195
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 43
+                    "u64": 10
                   }
                 }
               ]

--- a/contracts/reputation/test_snapshots/tests/test_contract_get_reputation_no_data.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_contract_get_reputation_no_data.1.json
@@ -189,7 +189,7 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
                     "u64": 0
@@ -197,7 +197,7 @@
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
                     "u64": 0

--- a/contracts/reputation/test_snapshots/tests/test_contract_set_and_get_reputation.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_contract_set_and_get_reputation.1.json
@@ -24,18 +24,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 20
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 100
+                        "u64": 20
                       }
                     }
                   ]
@@ -137,18 +137,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 20
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 100
+                        "u64": 20
                       }
                     }
                   ]
@@ -311,18 +311,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 20
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 100
+                        "u64": 20
                       }
                     }
                   ]
@@ -400,18 +400,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 20
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 100
+                    "u64": 20
                   }
                 }
               ]

--- a/contracts/reputation/test_snapshots/tests/test_get_ratings_isolated_between_artisans.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_get_ratings_isolated_between_artisans.1.json
@@ -606,18 +606,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -668,18 +668,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 20000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 2
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/reputation/test_snapshots/tests/test_get_ratings_limit_larger_than_remaining.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_get_ratings_limit_larger_than_remaining.1.json
@@ -770,18 +770,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 3
+                        "u64": 44800
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 12
+                        "u64": 3
                       }
                     }
                   ]

--- a/contracts/reputation/test_snapshots/tests/test_get_ratings_limit_zero_returns_empty.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_get_ratings_limit_zero_returns_empty.1.json
@@ -350,18 +350,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/reputation/test_snapshots/tests/test_get_ratings_offset_beyond_count_returns_empty.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_get_ratings_offset_beyond_count_returns_empty.1.json
@@ -350,18 +350,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/reputation/test_snapshots/tests/test_get_ratings_pagination_basic_page.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_get_ratings_pagination_basic_page.1.json
@@ -1193,18 +1193,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 33616
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 15
+                        "u64": 5
                       }
                     }
                   ]

--- a/contracts/reputation/test_snapshots/tests/test_get_ratings_records_rater_and_timestamp.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_get_ratings_records_rater_and_timestamp.1.json
@@ -350,18 +350,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 40000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 4
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/reputation/test_snapshots/tests/test_get_stats.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_get_stats.1.json
@@ -24,18 +24,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 2
+                        "u64": 45000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 9
+                        "u64": 2
                       }
                     }
                   ]
@@ -137,18 +137,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 2
+                        "u64": 45000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 9
+                        "u64": 2
                       }
                     }
                   ]
@@ -311,18 +311,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 2
+                        "u64": 45000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 9
+                        "u64": 2
                       }
                     }
                   ]

--- a/contracts/reputation/test_snapshots/tests/test_multiple_users_independent_reputation.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_multiple_users_independent_reputation.1.json
@@ -24,18 +24,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 10
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 50
+                        "u64": 10
                       }
                     }
                   ]
@@ -66,18 +66,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 15
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 75
+                        "u64": 15
                       }
                     }
                   ]
@@ -180,18 +180,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 10
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 50
+                        "u64": 10
                       }
                     }
                   ]
@@ -242,18 +242,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 15
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 75
+                        "u64": 15
                       }
                     }
                   ]
@@ -449,18 +449,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 10
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 50
+                        "u64": 10
                       }
                     }
                   ]
@@ -523,18 +523,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 15
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 75
+                        "u64": 15
                       }
                     }
                   ]
@@ -612,18 +612,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 10
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 50
+                    "u64": 10
                   }
                 }
               ]
@@ -678,18 +678,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 15
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 75
+                    "u64": 15
                   }
                 }
               ]

--- a/contracts/reputation/test_snapshots/tests/test_rate_artisan_prevents_double_rating.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_rate_artisan_prevents_double_rating.1.json
@@ -350,18 +350,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/reputation/test_snapshots/tests/test_rate_artisan_rejects_duplicate_caller_artisan_pair.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_rate_artisan_rejects_duplicate_caller_artisan_pair.1.json
@@ -351,18 +351,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]

--- a/contracts/reputation/test_snapshots/tests/test_rate_artisan_with_verified_completed_engagement.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_rate_artisan_with_verified_completed_engagement.1.json
@@ -350,18 +350,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 1
                       }
                     }
                   ]
@@ -903,18 +903,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 1
+                    "u64": 50000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 5
+                    "u64": 1
                   }
                 }
               ]

--- a/contracts/reputation/test_snapshots/tests/test_set_reputation_requires_admin_auth.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_set_reputation_requires_admin_auth.1.json
@@ -174,18 +174,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 2
+                        "u64": 50000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 10
+                        "u64": 2
                       }
                     }
                   ]
@@ -316,18 +316,18 @@
                       "map": [
                         {
                           "key": {
-                            "symbol": "review_count"
+                            "symbol": "ema_scaled"
                           },
                           "val": {
-                            "u64": 2
+                            "u64": 50000
                           }
                         },
                         {
                           "key": {
-                            "symbol": "total_stars"
+                            "symbol": "review_count"
                           },
                           "val": {
-                            "u64": 10
+                            "u64": 2
                           }
                         }
                       ]

--- a/contracts/reputation/test_snapshots/tests/test_update_existing_reputation.1.json
+++ b/contracts/reputation/test_snapshots/tests/test_update_existing_reputation.1.json
@@ -24,18 +24,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 30000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 30
+                        "u64": 5
                       }
                     }
                   ]
@@ -66,18 +66,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 12
+                        "u64": 40000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 80
+                        "u64": 12
                       }
                     }
                   ]
@@ -179,18 +179,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 12
+                        "u64": 40000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 80
+                        "u64": 12
                       }
                     }
                   ]
@@ -386,18 +386,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 5
+                        "u64": 30000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 30
+                        "u64": 5
                       }
                     }
                   ]
@@ -460,18 +460,18 @@
                   "map": [
                     {
                       "key": {
-                        "symbol": "review_count"
+                        "symbol": "ema_scaled"
                       },
                       "val": {
-                        "u64": 12
+                        "u64": 40000
                       }
                     },
                     {
                       "key": {
-                        "symbol": "total_stars"
+                        "symbol": "review_count"
                       },
                       "val": {
-                        "u64": 80
+                        "u64": 12
                       }
                     }
                   ]
@@ -549,18 +549,18 @@
               "map": [
                 {
                   "key": {
-                    "symbol": "review_count"
+                    "symbol": "ema_scaled"
                   },
                   "val": {
-                    "u64": 12
+                    "u64": 40000
                   }
                 },
                 {
                   "key": {
-                    "symbol": "total_stars"
+                    "symbol": "review_count"
                   },
                   "val": {
-                    "u64": 80
+                    "u64": 12
                   }
                 }
               ]


### PR DESCRIPTION

Closes #341 
## Summary

- Replaced the simple `total_stars / review_count` average in `contracts/reputation/` with an exponential moving average (EMA) that weights recent ratings more heavily
- `ReputationData` now stores `ema_scaled` (average × 10,000) using integer math only — no floating point
- New ratings apply `new_ema = (old_ema × 0.8) + (rating × 0.2)` via scaled weights (8,000 / 2,000)
- Updated `get_stats` to return the EMA-based average (still scaled by 100 for API compatibility)
- Updated `dispute_resolution` jury eligibility to use `ema_scaled > 45_000` (strictly above 4.5 stars)

## Why

In a gig economy, recent performance matters more than historical ratings. A 5-star review from years ago should not carry the same weight as a 1-star review from yesterday. EMA achieves this without storing individual reviews in the aggregate struct, keeping Soroban storage costs low.

## Test plan

- [x] `cargo test -p reputation` — 31/31 passed
- [x] `cargo test -p dispute_resolution` — 38/38 passed
- [x] Unit tests prove EMA math (80/20 weighting, first-rating behavior)
- [x] Unit test confirms a recent 1-star review drops score faster than a simple mean (420 vs 480 after 20 five-star reviews)